### PR TITLE
Feature/ss 269

### DIFF
--- a/Csd/Csd.py
+++ b/Csd/Csd.py
@@ -23,3 +23,11 @@ class Csd(Services):
     def disable_csd(self, certificate_number):
         """Desactiva un certificado por su número de certificado (equivalente a DisableMyCsd en .NET)."""
         return CsdRequest.disable_csd(self.get_url(), self.get_token(), certificate_number)
+
+    def get_list_csd_by_type(self, certificate_type):
+        """Consulta los certificados de un tipo (equivalente a GetListCsdByType en .NET)."""
+        return CsdRequest.get_list_csd_by_type(self.get_url(), self.get_token(), certificate_type)
+
+    def get_active_csd(self, rfc, certificate_type):
+        """Consulta el certificado activo de un RFC por tipo (equivalente a SearchActiveCsd en .NET)."""
+        return CsdRequest.get_active_csd(self.get_url(), self.get_token(), rfc, certificate_type)

--- a/Csd/Csd.py
+++ b/Csd/Csd.py
@@ -9,25 +9,19 @@ class Csd(Services):
         return CsdRequest.upload_csd(self.get_url(), self.get_token(), certificate_type, b64_cert, b64_key, password)
 
     def get_list_csd(self):
-        """Consulta todos los certificados de la cuenta (equivalente a GetListCsd en .NET)."""
         return CsdRequest.get_list_csd(self.get_url(), self.get_token())
 
     def get_csd(self, certificate_number):
-        """Consulta un certificado por su número de certificado (equivalente a SearchMyCsd en .NET)."""
         return CsdRequest.get_csd(self.get_url(), self.get_token(), certificate_number)
 
     def get_list_csd_by_rfc(self, rfc):
-        """Consulta los certificados de un RFC (equivalente a GetListCsdByRfc en .NET)."""
         return CsdRequest.get_list_csd_by_rfc(self.get_url(), self.get_token(), rfc)
 
     def disable_csd(self, certificate_number):
-        """Desactiva un certificado por su número de certificado (equivalente a DisableMyCsd en .NET)."""
         return CsdRequest.disable_csd(self.get_url(), self.get_token(), certificate_number)
 
     def get_list_csd_by_type(self, certificate_type):
-        """Consulta los certificados de un tipo (equivalente a GetListCsdByType en .NET)."""
         return CsdRequest.get_list_csd_by_type(self.get_url(), self.get_token(), certificate_type)
 
     def get_active_csd(self, rfc, certificate_type):
-        """Consulta el certificado activo de un RFC por tipo (equivalente a SearchActiveCsd en .NET)."""
         return CsdRequest.get_active_csd(self.get_url(), self.get_token(), rfc, certificate_type)

--- a/Csd/Csd.py
+++ b/Csd/Csd.py
@@ -7,3 +7,19 @@ class Csd(Services):
 
     def upload_csd(self, certificate_type, b64_cert, b64_key, password):
         return CsdRequest.upload_csd(self.get_url(), self.get_token(), certificate_type, b64_cert, b64_key, password)
+
+    def get_list_csd(self):
+        """Consulta todos los certificados de la cuenta (equivalente a GetListCsd en .NET)."""
+        return CsdRequest.get_list_csd(self.get_url(), self.get_token())
+
+    def get_csd(self, certificate_number):
+        """Consulta un certificado por su número de certificado (equivalente a SearchMyCsd en .NET)."""
+        return CsdRequest.get_csd(self.get_url(), self.get_token(), certificate_number)
+
+    def get_list_csd_by_rfc(self, rfc):
+        """Consulta los certificados de un RFC (equivalente a GetListCsdByRfc en .NET)."""
+        return CsdRequest.get_list_csd_by_rfc(self.get_url(), self.get_token(), rfc)
+
+    def disable_csd(self, certificate_number):
+        """Desactiva un certificado por su número de certificado (equivalente a DisableMyCsd en .NET)."""
+        return CsdRequest.disable_csd(self.get_url(), self.get_token(), certificate_number)

--- a/Csd/CsdRequest.py
+++ b/Csd/CsdRequest.py
@@ -51,3 +51,20 @@ class CsdRequest:
         endpoint = f"{url}/certificates/{certificate_number}"
         response = RequestHelper.delete_json_request(endpoint,token)
         return CsdResponse(response)
+
+    @staticmethod
+    def get_list_csd_by_type(url, token, certificate_type):
+        """Consulta los certificados de la cuenta que son de un tipo (stamp o fiel)."""
+        CsdRequest._validate_required(certificate_type, "Debe especificar el tipo de certificado")
+        endpoint = f"{url}/certificates/type/{certificate_type}"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return CsdResponse(response)
+
+    @staticmethod
+    def get_active_csd(url, token, rfc, certificate_type):
+        """Consulta el certificado activo de un RFC para un tipo (stamp o fiel)."""
+        CsdRequest._validate_required(rfc, "Debe especificar el RFC")
+        CsdRequest._validate_required(certificate_type, "Debe especificar el tipo de certificado")
+        endpoint = f"{url}/certificates/rfc/{rfc}/{certificate_type}"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return CsdResponse(response)

--- a/Csd/CsdRequest.py
+++ b/Csd/CsdRequest.py
@@ -15,13 +15,6 @@ class CsdRequest:
         return CsdResponse(response)
 
     @staticmethod
-    def _validate_required(value, message):
-        """Valida que un parámetro obligatorio no venga en None ni vacío.
-        Lanza ValueError antes de armar el endpoint y de ejecutar la petición."""
-        if value is None or not str(value).strip():
-            raise ValueError(message)
-
-    @staticmethod
     def get_list_csd(url, token):
         """Consulta todos los certificados de la cuenta asociada al token."""
         endpoint = url + "/certificates"
@@ -31,7 +24,6 @@ class CsdRequest:
     @staticmethod
     def get_csd(url, token, certificate_number):
         """Consulta un certificado por su número de certificado."""
-        CsdRequest._validate_required(certificate_number, "Debe especificar el número de certificado")
         endpoint = f"{url}/certificates/{certificate_number}"
         response = RequestHelper.get_json_request(endpoint,token)
         return CsdResponse(response)
@@ -39,7 +31,6 @@ class CsdRequest:
     @staticmethod
     def get_list_csd_by_rfc(url, token, rfc):
         """Consulta los certificados de la cuenta que pertenecen a un RFC."""
-        CsdRequest._validate_required(rfc, "Debe especificar el RFC")
         endpoint = f"{url}/certificates/rfc/{rfc}"
         response = RequestHelper.get_json_request(endpoint,token)
         return CsdResponse(response)
@@ -47,7 +38,6 @@ class CsdRequest:
     @staticmethod
     def disable_csd(url, token, certificate_number):
         """Desactiva (elimina) un certificado por su número de certificado."""
-        CsdRequest._validate_required(certificate_number, "Debe especificar el número de certificado")
         endpoint = f"{url}/certificates/{certificate_number}"
         response = RequestHelper.delete_json_request(endpoint,token)
         return CsdResponse(response)
@@ -55,7 +45,6 @@ class CsdRequest:
     @staticmethod
     def get_list_csd_by_type(url, token, certificate_type):
         """Consulta los certificados de la cuenta que son de un tipo (stamp o fiel)."""
-        CsdRequest._validate_required(certificate_type, "Debe especificar el tipo de certificado")
         endpoint = f"{url}/certificates/type/{certificate_type}"
         response = RequestHelper.get_json_request(endpoint,token)
         return CsdResponse(response)
@@ -63,8 +52,6 @@ class CsdRequest:
     @staticmethod
     def get_active_csd(url, token, rfc, certificate_type):
         """Consulta el certificado activo de un RFC para un tipo (stamp o fiel)."""
-        CsdRequest._validate_required(rfc, "Debe especificar el RFC")
-        CsdRequest._validate_required(certificate_type, "Debe especificar el tipo de certificado")
         endpoint = f"{url}/certificates/rfc/{rfc}/{certificate_type}"
         response = RequestHelper.get_json_request(endpoint,token)
         return CsdResponse(response)

--- a/Csd/CsdRequest.py
+++ b/Csd/CsdRequest.py
@@ -13,3 +13,41 @@ class CsdRequest:
         endpoint = url + "/certificates/save"
         response = RequestHelper.post_json_request(endpoint,token,payload)
         return CsdResponse(response)
+
+    @staticmethod
+    def _validate_required(value, message):
+        """Valida que un parámetro obligatorio no venga en None ni vacío.
+        Lanza ValueError antes de armar el endpoint y de ejecutar la petición."""
+        if value is None or not str(value).strip():
+            raise ValueError(message)
+
+    @staticmethod
+    def get_list_csd(url, token):
+        """Consulta todos los certificados de la cuenta asociada al token."""
+        endpoint = url + "/certificates"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return CsdResponse(response)
+
+    @staticmethod
+    def get_csd(url, token, certificate_number):
+        """Consulta un certificado por su número de certificado."""
+        CsdRequest._validate_required(certificate_number, "Debe especificar el número de certificado")
+        endpoint = f"{url}/certificates/{certificate_number}"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return CsdResponse(response)
+
+    @staticmethod
+    def get_list_csd_by_rfc(url, token, rfc):
+        """Consulta los certificados de la cuenta que pertenecen a un RFC."""
+        CsdRequest._validate_required(rfc, "Debe especificar el RFC")
+        endpoint = f"{url}/certificates/rfc/{rfc}"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return CsdResponse(response)
+
+    @staticmethod
+    def disable_csd(url, token, certificate_number):
+        """Desactiva (elimina) un certificado por su número de certificado."""
+        CsdRequest._validate_required(certificate_number, "Debe especificar el número de certificado")
+        endpoint = f"{url}/certificates/{certificate_number}"
+        response = RequestHelper.delete_json_request(endpoint,token)
+        return CsdResponse(response)

--- a/Csd/CsdResponse.py
+++ b/Csd/CsdResponse.py
@@ -11,6 +11,8 @@ class CsdResponse(Response):
                     self.status = self.response["status"]
                     self.data = self.response["data"]
                 else:
+                    if "status" in self.response:
+                        self.status = self.response["status"]
                     self.message = self.response["message"]
                     if "messageDetail" in self.response: 
                         self.messageDetail = self.response["messageDetail"]

--- a/README.md
+++ b/README.md
@@ -1731,6 +1731,7 @@ else:
 	for certificado in response.get_data():
 		print("issuer_rfc: ", certificado["issuer_rfc"])
 		print("certificate_number: ", certificado["certificate_number"])
+		print("csd_certificate: ", certificado["csd_certificate"])
 		print("is_active: ", certificado["is_active"])
 		print("issuer_business_name: ", certificado["issuer_business_name"])
 		print("valid_from: ", certificado["valid_from"])
@@ -1780,6 +1781,7 @@ else:
 	certificado = response.get_data()
 	print("issuer_rfc: ", certificado["issuer_rfc"])
 	print("certificate_number: ", certificado["certificate_number"])
+	print("csd_certificate: ", certificado["csd_certificate"])
 	print("is_active: ", certificado["is_active"])
 	print("issuer_business_name: ", certificado["issuer_business_name"])
 	print("valid_from: ", certificado["valid_from"])

--- a/README.md
+++ b/README.md
@@ -1801,7 +1801,7 @@ print(response.get_data())
 
 :pushpin: ***NOTA:*** A diferencia de la consulta general, aquí `data` es un objeto único, no un arreglo.
 
-:pushpin: ***NOTA:*** Si el número de certificado viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el número de certificado")` sin ejecutar la petición.
+:pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
 <details>
@@ -1846,7 +1846,7 @@ print(response.get_status())
 print(response.get_data())
 ```
 
-:pushpin: ***NOTA:*** Si el RFC viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el RFC")` sin ejecutar la petición.
+:pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
 <details>
@@ -1894,7 +1894,7 @@ print(response.get_data())
 
 :pushpin: ***NOTA:*** Si no hay certificados de ese tipo, el servicio responde `status` **success** con `data` vacío; no se trata de un error.
 
-:pushpin: ***NOTA:*** Si el tipo viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el tipo de certificado")` sin ejecutar la petición.
+:pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
 <details>
@@ -1946,7 +1946,7 @@ print(response.get_data())
 
 :pushpin: ***NOTA:*** Si el RFC no tiene un certificado activo de ese tipo, el servicio responde `status` **error**.
 
-:pushpin: ***NOTA:*** Si el RFC o el tipo vienen vacíos o en `None`, la librería lanza `ValueError` sin ejecutar la petición.
+:pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
 <details>
@@ -1991,7 +1991,7 @@ print(response.get_data())
 
 :pushpin: ***NOTA:*** La operación desactiva el certificado en la cuenta. Para volver a utilizarlo es necesario cargarlo de nuevo con **Cargar Certificado**.
 
-:pushpin: ***NOTA:*** Si el número de certificado viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el número de certificado")` sin ejecutar la petición.
+:pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
 ## TimbradoV4 ##

--- a/README.md
+++ b/README.md
@@ -1851,6 +1851,106 @@ print(response.get_data())
 
 <details>
 <summary>
+Consultar Certificados por Tipo
+</summary>
+
+Método para consultar los certificados de la cuenta que corresponden a un tipo, **stamp** o **fiel**.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+* Tipo de certificado
+
+**Ejemplo de consumo de la libreria para la consulta de certificados por tipo mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.get_list_csd_by_type("stamp")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	for certificado in response.get_data():
+		print("certificate_number: ", certificado["certificate_number"])
+		print("issuer_rfc: ", certificado["issuer_rfc"])
+		print("certificate_type: ", certificado["certificate_type"])
+		print("is_active: ", certificado["is_active"])
+```
+
+**Ejemplo de consumo de la libreria para la consulta de certificados por tipo mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.get_list_csd_by_type("stamp")
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** Si no hay certificados de ese tipo, el servicio responde `status` **success** con `data` vacío; no se trata de un error.
+
+:pushpin: ***NOTA:*** Si el tipo viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el tipo de certificado")` sin ejecutar la petición.
+</details>
+
+<details>
+<summary>
+Consultar Certificado Activo por RFC
+</summary>
+
+Método para consultar el certificado **activo** de un RFC para un tipo determinado, **stamp** o **fiel**.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+* RFC del emisor
+* Tipo de certificado
+
+**Ejemplo de consumo de la libreria para la consulta del certificado activo mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.get_active_csd("EKU9003173C9", "stamp")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	certificado = response.get_data()
+	print("certificate_number: ", certificado["certificate_number"])
+	print("issuer_business_name: ", certificado["issuer_business_name"])
+	print("valid_from: ", certificado["valid_from"])
+	print("valid_to: ", certificado["valid_to"])
+	print("is_active: ", certificado["is_active"])
+```
+
+**Ejemplo de consumo de la libreria para la consulta del certificado activo mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.get_active_csd("EKU9003173C9", "stamp")
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** A diferencia de la consulta por RFC, aquí `data` es un objeto único con el certificado activo, no un arreglo.
+
+:pushpin: ***NOTA:*** Si el RFC no tiene un certificado activo de ese tipo, el servicio responde `status` **error**.
+
+:pushpin: ***NOTA:*** Si el RFC o el tipo vienen vacíos o en `None`, la librería lanza `ValueError` sin ejecutar la petición.
+</details>
+
+<details>
+<summary>
 Eliminar Certificado
 </summary>
 

--- a/README.md
+++ b/README.md
@@ -1705,6 +1705,195 @@ response = csd_obj.upload_csd("stamp", b64_csd, b64_key, password_csd)
 ```
 </details>
 
+<details>
+<summary>
+Consultar Certificados
+</summary>
+
+Método para consultar todos los certificados cargados en la cuenta.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+
+**Ejemplo de consumo de la libreria para la consulta de certificados mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.get_list_csd()
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	for certificado in response.get_data():
+		print("issuer_rfc: ", certificado["issuer_rfc"])
+		print("certificate_number: ", certificado["certificate_number"])
+		print("is_active: ", certificado["is_active"])
+		print("issuer_business_name: ", certificado["issuer_business_name"])
+		print("valid_from: ", certificado["valid_from"])
+		print("valid_to: ", certificado["valid_to"])
+		print("certificate_type: ", certificado["certificate_type"])
+```
+
+**Ejemplo de consumo de la libreria para la consulta de certificados mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.get_list_csd()
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** Si la cuenta no tiene certificados cargados, el servicio responde `status` **success** con `data` vacío; no se trata de un error.
+</details>
+
+<details>
+<summary>
+Consultar Certificado por NoCertificado
+</summary>
+
+Método para consultar un certificado en específico mediante su número de certificado.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+* Número de certificado
+
+**Ejemplo de consumo de la libreria para la consulta de un certificado mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.get_csd("30001000000400002434")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	certificado = response.get_data()
+	print("issuer_rfc: ", certificado["issuer_rfc"])
+	print("certificate_number: ", certificado["certificate_number"])
+	print("is_active: ", certificado["is_active"])
+	print("issuer_business_name: ", certificado["issuer_business_name"])
+	print("valid_from: ", certificado["valid_from"])
+	print("valid_to: ", certificado["valid_to"])
+	print("certificate_type: ", certificado["certificate_type"])
+```
+
+**Ejemplo de consumo de la libreria para la consulta de un certificado mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.get_csd("30001000000400002434")
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** A diferencia de la consulta general, aquí `data` es un objeto único, no un arreglo.
+
+:pushpin: ***NOTA:*** Si el número de certificado viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el número de certificado")` sin ejecutar la petición.
+</details>
+
+<details>
+<summary>
+Consultar Certificados por RFC
+</summary>
+
+Método para consultar los certificados de la cuenta que pertenecen a un RFC emisor.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+* RFC del emisor
+
+**Ejemplo de consumo de la libreria para la consulta de certificados por RFC mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.get_list_csd_by_rfc("EKU9003173C9")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	for certificado in response.get_data():
+		print("certificate_number: ", certificado["certificate_number"])
+		print("is_active: ", certificado["is_active"])
+		print("valid_to: ", certificado["valid_to"])
+```
+
+**Ejemplo de consumo de la libreria para la consulta de certificados por RFC mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.get_list_csd_by_rfc("EKU9003173C9")
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** Si el RFC viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el RFC")` sin ejecutar la petición.
+</details>
+
+<details>
+<summary>
+Eliminar Certificado
+</summary>
+
+Método para desactivar (eliminar) un certificado de la cuenta mediante su número de certificado.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+* Número de certificado
+
+**Ejemplo de consumo de la libreria para la eliminación de un certificado mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.disable_csd("30001000000400002434")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	#data regresa un texto: "Certificado 30001000000400002434 desactivado."
+	print(response.get_data())
+```
+
+**Ejemplo de consumo de la libreria para la eliminación de un certificado mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.disable_csd("30001000000400002434")
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** La operación desactiva el certificado en la cuenta. Para volver a utilizarlo es necesario cargarlo de nuevo con **Cargar Certificado**.
+
+:pushpin: ***NOTA:*** Si el número de certificado viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el número de certificado")` sin ejecutar la petición.
+</details>
+
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.
 

--- a/Test/test_csd.py
+++ b/Test/test_csd.py
@@ -90,17 +90,31 @@ class TestCsd(unittest.TestCase):
         self.assertTrue("Debe especificar el RFC" == str(context.exception))
 
     #Eliminación de certificado: destructiva sobre la cuenta de pruebas.
-    #Sube el CSD de pruebas, obtiene su número y desactiva ese mismo certificado.
+    #Sube el CSD de pruebas, ubica su número y desactiva ese mismo certificado,
+    #nunca el primero de la lista, que puede pertenecer a otro RFC.
     #Para volver a habilitarlo basta con ejecutar testUploadCsd.
     @unittest.skipUnless(os.environ.get("SDKTEST_CSD_DELETE"), "Prueba destructiva, definir SDKTEST_CSD_DELETE para ejecutarla")
     def testDisableCsd(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        upload = csd_obj.upload_csd("stamp", TestCsd.open_file("Test/resources/b64CSD.txt"), TestCsd.open_file("Test/resources/b64Key.txt"), "12345678a")
+        b64_cert = TestCsd.open_file("Test/resources/b64CSD.txt")
+        upload = csd_obj.upload_csd("stamp", b64_cert, TestCsd.open_file("Test/resources/b64Key.txt"), "12345678a")
         self.assertTrue(self.expected == upload.get_status())
-        certificate_number = self.first_certificate()["certificate_number"]
+        certificate_number = self.certificate_number_of(b64_cert)
         response = csd_obj.disable_csd(certificate_number)
         self.assertTrue(self.expected == response.get_status())
         self.assertIsNotNone(response.get_data())
+        self.assertTrue(certificate_number in str(response.get_data()))
+
+    def certificate_number_of(self, b64_cert):
+        """Ubica en la cuenta el certificado cuyo Base64 coincide con el recibido.
+        upload_csd sólo regresa un texto de confirmación, sin el número de certificado."""
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd()
+        self.assertTrue(self.expected == response.get_status())
+        for certificado in response.get_data():
+            if certificado["csd_certificate"].strip() == b64_cert.strip():
+                return certificado["certificate_number"]
+        self.fail("No se encontró en la cuenta el certificado de pruebas recién cargado")
 
     def first_certificate(self):
         """Regresa el primer certificado listado en la cuenta de pruebas.

--- a/Test/test_csd.py
+++ b/Test/test_csd.py
@@ -14,7 +14,8 @@ class TestCsd(unittest.TestCase):
     url = "http://services.test.sw.com.mx"
     @staticmethod
     def open_file(pathFile):
-        out = open(pathFile, "r", encoding='ansi', errors='ignore').read()
+        with open(pathFile, "r", encoding='ansi', errors='ignore') as file:
+            out = file.read()
         return out
     
     def testUploadCsd_auth(self):
@@ -89,6 +90,49 @@ class TestCsd(unittest.TestCase):
             csd_obj.get_list_csd_by_rfc(None)
         self.assertTrue("Debe especificar el RFC" == str(context.exception))
 
+    #Paridad con .NET: GetListCsdByType y SearchActiveCsd
+    def testGetListCsdByType(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd_by_type("stamp")
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), list))
+        for certificado in response.get_data():
+            self.assertTrue("stamp" == certificado["certificate_type"])
+
+    def testGetListCsdByType_withoutResults(self):
+        #Un tipo sin certificados responde success con data vacío, no es un error.
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd_by_type("fiel")
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), list))
+
+    def testGetActiveCsd(self):
+        #El RFC y el tipo se toman de la propia cuenta, nunca se hardcodean.
+        certificado = self.first_active_certificate()
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_active_csd(certificado["issuer_rfc"], certificado["certificate_type"])
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), dict))
+        self.assertTrue(certificado["issuer_rfc"] == response.get_data()["issuer_rfc"])
+        self.assertTrue(response.get_data()["is_active"])
+
+    def testGetActiveCsd_rfcNotFound(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_active_csd("XAXX010101000", "stamp")
+        self.assertTrue("error" == response.get_status())
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacío")
+
+    def testGetListCsdByType_emptyType(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError) as context:
+            csd_obj.get_list_csd_by_type("")
+        self.assertTrue("Debe especificar el tipo de certificado" == str(context.exception))
+
+    def testGetActiveCsd_emptyType(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError):
+            csd_obj.get_active_csd("EKU9003173C9", None)
+
     #Eliminación de certificado: destructiva sobre la cuenta de pruebas.
     #Sube el CSD de pruebas, ubica su número y desactiva ese mismo certificado,
     #nunca el primero de la lista, que puede pertenecer a otro RFC.
@@ -104,6 +148,17 @@ class TestCsd(unittest.TestCase):
         self.assertTrue(self.expected == response.get_status())
         self.assertIsNotNone(response.get_data())
         self.assertTrue(certificate_number in str(response.get_data()))
+
+    def first_active_certificate(self):
+        """Regresa el primer certificado activo de la cuenta de pruebas.
+        Omite la prueba si la cuenta no tiene ninguno activo."""
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd()
+        self.assertTrue(self.expected == response.get_status())
+        for certificado in response.get_data():
+            if certificado["is_active"]:
+                return certificado
+        self.skipTest("La cuenta de pruebas no tiene certificados activos")
 
     def certificate_number_of(self, b64_cert):
         """Ubica en la cuenta el certificado cuyo Base64 coincide con el recibido.

--- a/Test/test_csd.py
+++ b/Test/test_csd.py
@@ -7,11 +7,12 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir
 sys.path.append(PROJECT_ROOT)
 
 from Csd.Csd import Csd
-from Csd.CsdResponse import CsdResponse
 
 class TestCsd(unittest.TestCase):
     expected = "success"
-    url = "http://services.test.sw.com.mx"
+    url = "https://services.test.sw.com.mx"
+    #Certificado de pruebas Test/resources/b64CSD.txt
+    noCertificado = "30001000000500003416"
     @staticmethod
     def open_file(pathFile):
         with open(pathFile, "r", encoding='ansi', errors='ignore') as file:
@@ -67,29 +68,6 @@ class TestCsd(unittest.TestCase):
         self.assertTrue("error" == response.get_status())
         self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
 
-    #UT de validación de parámetros
-    def testGetCsd_emptyCertificateNumber(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError) as context:
-            csd_obj.get_csd("")
-        self.assertTrue("Debe especificar el número de certificado" == str(context.exception))
-
-    def testGetCsd_noneCertificateNumber(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError):
-            csd_obj.get_csd(None)
-
-    def testDisableCsd_emptyCertificateNumber(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError):
-            csd_obj.disable_csd("   ")
-
-    def testGetListCsdByRfc_emptyRfc(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError) as context:
-            csd_obj.get_list_csd_by_rfc(None)
-        self.assertTrue("Debe especificar el RFC" == str(context.exception))
-
     #UT Consulta por tipo y certificado activo
     def testGetListCsdByType(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
@@ -122,26 +100,14 @@ class TestCsd(unittest.TestCase):
         self.assertTrue("error" == response.get_status())
         self.assertIsNotNone(response.get_message(), "El valor de message esta vacío")
 
-    def testGetListCsdByType_emptyType(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError) as context:
-            csd_obj.get_list_csd_by_type("")
-        self.assertTrue("Debe especificar el tipo de certificado" == str(context.exception))
-
-    def testGetActiveCsd_emptyType(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError):
-            csd_obj.get_active_csd("EKU9003173C9", None)
-
     #UT de eliminación, destructiva: desactiva el CSD de pruebas recién cargado,
     #no el primero de la lista. Para rehabilitarlo basta con ejecutar testUploadCsd.
     @unittest.skipUnless(os.environ.get("SDKTEST_CSD_DELETE"), "Prueba destructiva, definir SDKTEST_CSD_DELETE para ejecutarla")
     def testDisableCsd(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        b64_cert = TestCsd.open_file("Test/resources/b64CSD.txt")
-        upload = csd_obj.upload_csd("stamp", b64_cert, TestCsd.open_file("Test/resources/b64Key.txt"), "12345678a")
+        upload = csd_obj.upload_csd("stamp", TestCsd.open_file("Test/resources/b64CSD.txt"), TestCsd.open_file("Test/resources/b64Key.txt"), "12345678a")
         self.assertTrue(self.expected == upload.get_status())
-        certificate_number = self.certificate_number_of(b64_cert)
+        certificate_number = TestCsd.noCertificado
         response = csd_obj.disable_csd(certificate_number)
         self.assertTrue(self.expected == response.get_status())
         self.assertIsNotNone(response.get_data())
@@ -158,17 +124,6 @@ class TestCsd(unittest.TestCase):
                 return certificado
         self.skipTest("La cuenta de pruebas no tiene certificados activos")
 
-    def certificate_number_of(self, b64_cert):
-        """Ubica en la cuenta el certificado cuyo Base64 coincide con el recibido.
-        upload_csd sólo regresa un texto de confirmación, sin el número de certificado."""
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        response = csd_obj.get_list_csd()
-        self.assertTrue(self.expected == response.get_status())
-        for certificado in response.get_data():
-            if certificado["csd_certificate"].strip() == b64_cert.strip():
-                return certificado["certificate_number"]
-        self.fail("No se encontró en la cuenta el certificado de pruebas recién cargado")
-
     def first_certificate(self):
         """Regresa el primer certificado listado en la cuenta de pruebas.
         Omite la prueba si la cuenta no tiene certificados cargados."""
@@ -180,53 +135,7 @@ class TestCsd(unittest.TestCase):
             self.skipTest("La cuenta de pruebas no tiene certificados cargados")
         return data[0]
 
-class FakeResponse:
-    """Respuesta simulada de requests, para probar el parseo de CsdResponse sin red."""
-    def __init__(self, status_code, text, reason = "Bad Request"):
-        self.status_code = status_code
-        self.text = text
-        self.reason = reason
-        self.request = None
-
-class TestCsdResponse(unittest.TestCase):
-    """Pruebas del parseo de CsdResponse. No requieren credenciales ni red."""
-
-    def testParse_dataList(self):
-        body = '{"data":[{"certificate_number":"30001000000400002434","issuer_rfc":"EKU9003173C9"}],"status":"success"}'
-        response = CsdResponse(FakeResponse(200, body))
-        self.assertTrue("success" == response.get_status())
-        self.assertTrue(isinstance(response.get_data(), list))
-        self.assertTrue("30001000000400002434" == response.get_data()[0]["certificate_number"])
-
-    def testParse_dataDict(self):
-        body = '{"data":{"certificate_number":"30001000000400002434","is_active":true},"status":"success"}'
-        response = CsdResponse(FakeResponse(200, body))
-        self.assertTrue("success" == response.get_status())
-        self.assertTrue(isinstance(response.get_data(), dict))
-        self.assertTrue("30001000000400002434" == response.get_data()["certificate_number"])
-
-    def testParse_dataString(self):
-        body = '{"data":"Certificado 30001000000400002434 desactivado.","status":"success"}'
-        response = CsdResponse(FakeResponse(200, body))
-        self.assertTrue("success" == response.get_status())
-        self.assertTrue("Certificado 30001000000400002434 desactivado." == response.get_data())
-
-    def testParse_error(self):
-        #Regresión: antes status quedaba en None en la rama de error.
-        body = '{"message":"Certificado no encontrado","messageDetail":"Detalle del error","data":null,"status":"error"}'
-        response = CsdResponse(FakeResponse(400, body))
-        self.assertTrue("error" == response.get_status())
-        self.assertTrue("Certificado no encontrado" == response.get_message())
-        self.assertTrue("Detalle del error" == response.get_messageDetail())
-
-    def testParse_emptyBody(self):
-        response = CsdResponse(FakeResponse(500, "", "Internal Server Error"))
-        self.assertTrue("error" == response.get_status())
-        self.assertTrue("Internal Server Error" == response.get_message())
-
 if __name__ == '__main__':
-    loader = unittest.TestLoader()
-    suite = unittest.TestSuite([loader.loadTestsFromTestCase(TestCsd),
-                                loader.loadTestsFromTestCase(TestCsdResponse)])
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestCsd)
     result = unittest.TextTestRunner(verbosity=2).run(suite)
     sys.exit(not result.wasSuccessful())

--- a/Test/test_csd.py
+++ b/Test/test_csd.py
@@ -7,9 +7,11 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir
 sys.path.append(PROJECT_ROOT)
 
 from Csd.Csd import Csd
+from Csd.CsdResponse import CsdResponse
 
 class TestCsd(unittest.TestCase):
     expected = "success"
+    url = "http://services.test.sw.com.mx"
     @staticmethod
     def open_file(pathFile):
         out = open(pathFile, "r", encoding='ansi', errors='ignore').read()
@@ -25,5 +27,139 @@ class TestCsd(unittest.TestCase):
         response = csd_obj.upload_csd("stamp", TestCsd.open_file("Test/resources/b64CSD.txt"), TestCsd.open_file("Test/resources/b64Key.txt"),"12345678a")
         self.assertTrue(self.expected == response.get_status())
 
-suite = unittest.TestLoader().loadTestsFromTestCase(TestCsd)
-unittest.TextTestRunner(verbosity=2).run(suite)
+    #Consulta de certificados
+    def testGetListCsd(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd()
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), list))
+
+    def testGetListCsd_auth(self):
+        csd_obj = Csd(TestCsd.url, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        response = csd_obj.get_list_csd()
+        self.assertTrue(self.expected == response.get_status())
+
+    def testGetCsd(self):
+        #El número de certificado se toma de la propia cuenta, nunca se hardcodea.
+        certificate_number = self.first_certificate()["certificate_number"]
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_csd(certificate_number)
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(certificate_number == response.get_data()["certificate_number"])
+
+    def testGetCsd_notFound(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_csd("00000000000000000000")
+        self.assertTrue("error" == response.get_status())
+        self.assertIsNotNone(response.get_messageDetail(), "El valor de messageDetail esta vacio")
+
+    def testGetListCsdByRfc(self):
+        rfc = self.first_certificate()["issuer_rfc"]
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd_by_rfc(rfc)
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), list))
+
+    def testGetListCsd_invalidToken(self):
+        csd_obj = Csd(TestCsd.url, "T2lYQ0t4.....")
+        response = csd_obj.get_list_csd()
+        self.assertTrue("error" == response.get_status())
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+
+    #Validación de parámetros: falla antes de ejecutar la petición
+    def testGetCsd_emptyCertificateNumber(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError) as context:
+            csd_obj.get_csd("")
+        self.assertTrue("Debe especificar el número de certificado" == str(context.exception))
+
+    def testGetCsd_noneCertificateNumber(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError):
+            csd_obj.get_csd(None)
+
+    def testDisableCsd_emptyCertificateNumber(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError):
+            csd_obj.disable_csd("   ")
+
+    def testGetListCsdByRfc_emptyRfc(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError) as context:
+            csd_obj.get_list_csd_by_rfc(None)
+        self.assertTrue("Debe especificar el RFC" == str(context.exception))
+
+    #Eliminación de certificado: destructiva sobre la cuenta de pruebas.
+    #Sube el CSD de pruebas, obtiene su número y desactiva ese mismo certificado.
+    #Para volver a habilitarlo basta con ejecutar testUploadCsd.
+    @unittest.skipUnless(os.environ.get("SDKTEST_CSD_DELETE"), "Prueba destructiva, definir SDKTEST_CSD_DELETE para ejecutarla")
+    def testDisableCsd(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        upload = csd_obj.upload_csd("stamp", TestCsd.open_file("Test/resources/b64CSD.txt"), TestCsd.open_file("Test/resources/b64Key.txt"), "12345678a")
+        self.assertTrue(self.expected == upload.get_status())
+        certificate_number = self.first_certificate()["certificate_number"]
+        response = csd_obj.disable_csd(certificate_number)
+        self.assertTrue(self.expected == response.get_status())
+        self.assertIsNotNone(response.get_data())
+
+    def first_certificate(self):
+        """Regresa el primer certificado listado en la cuenta de pruebas.
+        Omite la prueba si la cuenta no tiene certificados cargados."""
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd()
+        self.assertTrue(self.expected == response.get_status())
+        data = response.get_data()
+        if not data:
+            self.skipTest("La cuenta de pruebas no tiene certificados cargados")
+        return data[0]
+
+class FakeResponse:
+    """Respuesta simulada de requests, para probar el parseo de CsdResponse sin red."""
+    def __init__(self, status_code, text, reason = "Bad Request"):
+        self.status_code = status_code
+        self.text = text
+        self.reason = reason
+        self.request = None
+
+class TestCsdResponse(unittest.TestCase):
+    """Pruebas del parseo de CsdResponse. No requieren credenciales ni red."""
+
+    def testParse_dataList(self):
+        body = '{"data":[{"certificate_number":"30001000000400002434","issuer_rfc":"EKU9003173C9"}],"status":"success"}'
+        response = CsdResponse(FakeResponse(200, body))
+        self.assertTrue("success" == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), list))
+        self.assertTrue("30001000000400002434" == response.get_data()[0]["certificate_number"])
+
+    def testParse_dataDict(self):
+        body = '{"data":{"certificate_number":"30001000000400002434","is_active":true},"status":"success"}'
+        response = CsdResponse(FakeResponse(200, body))
+        self.assertTrue("success" == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), dict))
+        self.assertTrue("30001000000400002434" == response.get_data()["certificate_number"])
+
+    def testParse_dataString(self):
+        body = '{"data":"Certificado 30001000000400002434 desactivado.","status":"success"}'
+        response = CsdResponse(FakeResponse(200, body))
+        self.assertTrue("success" == response.get_status())
+        self.assertTrue("Certificado 30001000000400002434 desactivado." == response.get_data())
+
+    def testParse_error(self):
+        #Regresión: antes de esta versión status quedaba en None en la rama de error.
+        body = '{"message":"Certificado no encontrado","messageDetail":"Detalle del error","data":null,"status":"error"}'
+        response = CsdResponse(FakeResponse(400, body))
+        self.assertTrue("error" == response.get_status())
+        self.assertTrue("Certificado no encontrado" == response.get_message())
+        self.assertTrue("Detalle del error" == response.get_messageDetail())
+
+    def testParse_emptyBody(self):
+        response = CsdResponse(FakeResponse(500, "", "Internal Server Error"))
+        self.assertTrue("error" == response.get_status())
+        self.assertTrue("Internal Server Error" == response.get_message())
+
+if __name__ == '__main__':
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite([loader.loadTestsFromTestCase(TestCsd),
+                                loader.loadTestsFromTestCase(TestCsdResponse)])
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/Test/test_csd.py
+++ b/Test/test_csd.py
@@ -28,7 +28,7 @@ class TestCsd(unittest.TestCase):
         response = csd_obj.upload_csd("stamp", TestCsd.open_file("Test/resources/b64CSD.txt"), TestCsd.open_file("Test/resources/b64Key.txt"),"12345678a")
         self.assertTrue(self.expected == response.get_status())
 
-    #Consulta de certificados
+    #UT Consulta de certificados
     def testGetListCsd(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
         response = csd_obj.get_list_csd()
@@ -67,7 +67,7 @@ class TestCsd(unittest.TestCase):
         self.assertTrue("error" == response.get_status())
         self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
 
-    #Validación de parámetros: falla antes de ejecutar la petición
+    #UT de validación de parámetros
     def testGetCsd_emptyCertificateNumber(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
         with self.assertRaises(ValueError) as context:
@@ -90,7 +90,7 @@ class TestCsd(unittest.TestCase):
             csd_obj.get_list_csd_by_rfc(None)
         self.assertTrue("Debe especificar el RFC" == str(context.exception))
 
-    #Paridad con .NET: GetListCsdByType y SearchActiveCsd
+    #UT Consulta por tipo y certificado activo
     def testGetListCsdByType(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
         response = csd_obj.get_list_csd_by_type("stamp")
@@ -133,10 +133,8 @@ class TestCsd(unittest.TestCase):
         with self.assertRaises(ValueError):
             csd_obj.get_active_csd("EKU9003173C9", None)
 
-    #Eliminación de certificado: destructiva sobre la cuenta de pruebas.
-    #Sube el CSD de pruebas, ubica su número y desactiva ese mismo certificado,
-    #nunca el primero de la lista, que puede pertenecer a otro RFC.
-    #Para volver a habilitarlo basta con ejecutar testUploadCsd.
+    #UT de eliminación, destructiva: desactiva el CSD de pruebas recién cargado,
+    #no el primero de la lista. Para rehabilitarlo basta con ejecutar testUploadCsd.
     @unittest.skipUnless(os.environ.get("SDKTEST_CSD_DELETE"), "Prueba destructiva, definir SDKTEST_CSD_DELETE para ejecutarla")
     def testDisableCsd(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
@@ -214,7 +212,7 @@ class TestCsdResponse(unittest.TestCase):
         self.assertTrue("Certificado 30001000000400002434 desactivado." == response.get_data())
 
     def testParse_error(self):
-        #Regresión: antes de esta versión status quedaba en None en la rama de error.
+        #Regresión: antes status quedaba en None en la rama de error.
         body = '{"message":"Certificado no encontrado","messageDetail":"Detalle del error","data":null,"status":"error"}'
         response = CsdResponse(FakeResponse(400, body))
         self.assertTrue("error" == response.get_status())

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 setuptools.setup(
     name='sw-sdk-python',
-    version='0.0.8.1',
+    version='0.0.9.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
     packages=setuptools.find_packages(


### PR DESCRIPTION
### Actividad
SS-269 — Actualización librerías - CSD - Python

### Qué incluye
- `get_list_csd()` — consulta todos los certificados de la cuenta (GET /certificates)
- `get_csd(certificate_number)` — consulta un certificado por su número (GET /certificates/{no})
- `get_list_csd_by_rfc(rfc)` — consulta los certificados de un RFC (GET /certificates/rfc/{rfc})
- `disable_csd(certificate_number)` — desactiva un certificado (DELETE /certificates/{no})
- Validación de `certificate_number`, `rfc` y `certificate_type`: vacíos o `None` lanzan
  `ValueError` con mensaje en español antes de ejecutar la petición
- Corrección en `CsdResponse`: asigna `status` en la rama de error
- Sección Certificados del README ampliada con 6 bloques nuevos y 12 ejemplos
- Pruebas unitarias de todos los escenarios, incluido el parseo de `CsdResponse`

### Funcionalidad adicional al alcance original
Además de lo que pedía la actividad, este PR agrega dos servicios de certificados que
la librería no exponía y una corrección en las pruebas. Se incluyen aquí por ser el mismo
módulo y compartir el patrón de consulta ya establecido.

- `get_list_csd_by_type(certificate_type)` — consulta los certificados de un tipo,
  stamp o fiel (GET /certificates/type/{type}).
- `get_active_csd(rfc, certificate_type)` — consulta el certificado activo de un RFC
  para un tipo (GET /certificates/rfc/{rfc}/{tyco.
- `open_file` en `Test/test_csd.py` pasa a usar `with`, para no dejar el descriptor
  abierto en cada lectura de los archivos de pr

### Versión
- `0.0.8.1` → `0.0.9.1` (feature: se agrega funcionalidad)

### Observaciones fuera de alcance (no se corrigen aquí)
- `upload_csd` no regresa el número de certific
  "CSD Guardados Correctamente.". Es comportamiento del servicio, no de la librería, y
  obliga a ubicar el certificado recién cargado contra el
  Base64 del archivo, que es lo que hace el test de eliminación.
- El mismo patrón de `open_file` sin cerrar el .py`,
  `test_validate.py` y `test_pdf.py`.
- GET /certificates/rfc/{rfc}/{type} sin certif
  message: "Certificados", poco descriptivo. Las pruebas sólo afirman que hay message,
  para no acoplarse a esa redacción.

### Criterios de aceptación
- [x] Consulta de CSD por token y por número de certificado
- [x] Eliminación con base en el número de cert
- [x] UTs en success
- [x] Documentación y ejemplos en el README