### PR TITLE
Feature/ss 271

### DIFF
--- a/README.md
+++ b/README.md
@@ -2087,9 +2087,7 @@ else:
 
 :pushpin: ***NOTA:*** El comprobante tarda alrededor de un minuto en quedar disponible en la consulta después de timbrarse. Durante ese lapso la respuesta es `success` con `records` vacío.
 
-:pushpin: ***NOTA:*** El campo con la url del PDF viene como `urlPDF`. El método `get_url_pdf()` contempla también la variante `urlPdf`, y si se recorren los registros directamente conviene usar `.get()` para no depender del casing. El campo llega vacío mientras no se haya generado el PDF del comprobante.
-
-:pushpin: ***NOTA:*** Las pruebas unitarias de este servicio (`Test/test_storage.py`) requieren la variable de entorno `SDKTEST_UUID` con el UUID de un CFDI timbrado en la cuenta de pruebas, además de las ya conocidas `SDKTEST_USER`, `SDKTEST_PASSWORD` y `SDKTEST_TOKEN`.
+:pushpin: ***NOTA:*** `get_url_pdf()` regresa vacío mientras no se haya generado el PDF del comprobante.
 
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.

--- a/README.md
+++ b/README.md
@@ -2010,7 +2010,7 @@ Este metodo recibe los siguientes parametros:
 * Url Servicios SW
 * Url Api
 * Token
-* UUID del CFDI
+* UUID del CFDI, como cadena o como `uuid.UUID`
 
 **Ejemplo de consumo de la libreria para la recuperación de un XML mediante token**
 ```py
@@ -2025,7 +2025,8 @@ if response.get_status() ==  "error":
 	print(response.get_messageDetail())
 else:
 	print(response.get_status())
-	#Un UUID sin coincidencias regresa una lista vacía.
+	#Un UUID sin coincidencias regresa una lista vacía. El comprobante recién timbrado
+	#tarda alrededor de un minuto en quedar disponible en la consulta.
 	for registro in response.get_records():
 		print("UUID: ", registro.get("uuid"))
 		print("Serie: ", registro.get("serie"))
@@ -2060,7 +2061,7 @@ Este metodo recibe los siguientes parametros:
 * Url Servicios SW
 * Url Api
 * Usuario y contraseña
-* UUID del CFDI
+* UUID del CFDI, como cadena o como `uuid.UUID`
 
 **Ejemplo de consumo de la libreria para la recuperación de un XML mediante usuario y contraseña**
 ```py
@@ -2078,16 +2079,6 @@ else:
 	print("Url de descarga del XML: ", response.get_url_xml())
 ```
 </details>
-
-:pushpin: ***NOTA:*** La url base de este servicio es la de la **API** (`https://api.test.sw.com.mx`), no la de servicios. La url de servicios sólo se utiliza para autenticar con usuario y contraseña.
-
-:pushpin: ***NOTA:*** Si el UUID no existe, está mal escrito o no fue timbrado con la cuenta autenticada, el servicio responde `status` **success** con `records` vacío. Esto no es un error: se consulta con `get_records()`, que regresa una lista vacía, o con `get_first_record()`, que regresa `None`.
-
-:pushpin: ***NOTA:*** El UUID puede enviarse como cadena o como `uuid.UUID`. La librería no valida el formato en local: se envía tal cual y responde el servicio.
-
-:pushpin: ***NOTA:*** El comprobante tarda alrededor de un minuto en quedar disponible en la consulta después de timbrarse. Durante ese lapso la respuesta es `success` con `records` vacío.
-
-:pushpin: ***NOTA:*** `get_url_pdf()` regresa vacío mientras no se haya generado el PDF del comprobante.
 
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.

--- a/README.md
+++ b/README.md
@@ -1996,6 +1996,90 @@ print(response.get_data())
 :pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
+## Recuperar XML por UUID ##
+Servicio para recuperar la información y las URLs de descarga de un CFDI timbrado con SW a partir de su UUID.
+
+<details>
+<summary>
+Recuperar XML por UUID mediante token
+</summary>
+
+Método para consultar un CFDI timbrado en la cuenta mediante su UUID.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Url Api
+* Token
+* UUID del CFDI
+
+**Ejemplo de consumo de la libreria para la recuperación de un XML mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Storage.Storage import Storage
+
+storage_obj = Storage("https://services.test.sw.com.mx", "https://api.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = storage_obj.get_by_uuid("d3773788-c68a-4549-ac67-f223d26c925b")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	print(response.get_status())
+	#Un UUID sin coincidencias regresa una lista vacía.
+	for registro in response.get_records():
+		print("UUID: ", registro.get("uuid"))
+		print("Serie: ", registro.get("serie"))
+		print("Folio: ", registro.get("folio"))
+		print("Total: ", registro.get("total"))
+		print("RFC Emisor: ", registro.get("rfcEmisor"))
+		print("RFC Receptor: ", registro.get("rfcReceptor"))
+		print("Url XML: ", registro.get("urlXml"))
+	#Atajos para el primer registro de la consulta
+	print("Url de descarga del XML: ", response.get_url_xml())
+	print("Url de descarga del PDF: ", response.get_url_pdf())
+```
+</details>
+
+<details>
+<summary>
+Recuperar XML por UUID mediante usuario y contraseña
+</summary>
+
+Método para consultar un CFDI timbrado en la cuenta mediante su UUID, autenticando con usuario y contraseña.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Url Api
+* Usuario y contraseña
+* UUID del CFDI
+
+**Ejemplo de consumo de la libreria para la recuperación de un XML mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Storage.Storage import Storage
+
+storage_obj = Storage("https://services.test.sw.com.mx", "https://api.test.sw.com.mx", None, "user", "password")
+response = storage_obj.get_by_uuid("d3773788-c68a-4549-ac67-f223d26c925b")
+
+print(response.get_status())
+registro = response.get_first_record()
+if registro is None:
+	print("El UUID no se encontró en la cuenta")
+else:
+	print("Url de descarga del XML: ", response.get_url_xml())
+```
+</details>
+
+:pushpin: ***NOTA:*** La url base de este servicio es la de la **API** (`https://api.test.sw.com.mx`), no la de servicios. La url de servicios sólo se utiliza para autenticar con usuario y contraseña.
+
+:pushpin: ***NOTA:*** Si el UUID no existe, está mal escrito o no fue timbrado con la cuenta autenticada, el servicio responde `status` **success** con `records` vacío. Esto no es un error: se consulta con `get_records()`, que regresa una lista vacía, o con `get_first_record()`, que regresa `None`.
+
+:pushpin: ***NOTA:*** El UUID puede enviarse como cadena o como `uuid.UUID`. La librería no valida el formato en local: se envía tal cual y responde el servicio.
+
+:pushpin: ***NOTA:*** La documentación oficial nombra el campo del PDF como `urlPDF` y el SDK de .NET como `urlPdf`. El método `get_url_pdf()` contempla ambas variantes; si se recorren los registros directamente conviene usar `.get()` para no depender del casing.
+
+:pushpin: ***NOTA:*** Las pruebas unitarias de este servicio (`Test/test_storage.py`) requieren la variable de entorno `SDKTEST_UUID` con el UUID de un CFDI timbrado en la cuenta de pruebas, además de las ya conocidas `SDKTEST_USER`, `SDKTEST_PASSWORD` y `SDKTEST_TOKEN`.
+
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.
 

--- a/README.md
+++ b/README.md
@@ -2039,6 +2039,13 @@ else:
 	#Atajos para el primer registro de la consulta
 	print("Url de descarga del XML: ", response.get_url_xml())
 	print("Url de descarga del PDF: ", response.get_url_pdf())
+	#Descargamos el XML
+	if response.get_url_xml():
+		import requests
+		xml = requests.get(response.get_url_xml()).content
+		f = open('file.xml', 'wb')
+		f.write(xml)
+		f.close()
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -2030,9 +2030,11 @@ else:
 		print("UUID: ", registro.get("uuid"))
 		print("Serie: ", registro.get("serie"))
 		print("Folio: ", registro.get("folio"))
+		print("Fecha: ", registro.get("fecha"))
 		print("Total: ", registro.get("total"))
-		print("RFC Emisor: ", registro.get("rfcEmisor"))
-		print("RFC Receptor: ", registro.get("rfcReceptor"))
+		print("Emisor: ", registro.get("emisorRfc"), registro.get("emisorNombre"))
+		print("Receptor: ", registro.get("receptorRfc"), registro.get("receptorNombre"))
+		print("Estatus SAT: ", registro.get("statusSAT"))
 		print("Url XML: ", registro.get("urlXml"))
 	#Atajos para el primer registro de la consulta
 	print("Url de descarga del XML: ", response.get_url_xml())
@@ -2076,7 +2078,9 @@ else:
 
 :pushpin: ***NOTA:*** El UUID puede enviarse como cadena o como `uuid.UUID`. La librería no valida el formato en local: se envía tal cual y responde el servicio.
 
-:pushpin: ***NOTA:*** La documentación oficial nombra el campo del PDF como `urlPDF` y el SDK de .NET como `urlPdf`. El método `get_url_pdf()` contempla ambas variantes; si se recorren los registros directamente conviene usar `.get()` para no depender del casing.
+:pushpin: ***NOTA:*** El comprobante tarda alrededor de un minuto en quedar disponible en la consulta después de timbrarse. Durante ese lapso la respuesta es `success` con `records` vacío.
+
+:pushpin: ***NOTA:*** El campo con la url del PDF viene como `urlPDF`; el SDK de .NET lo nombra `urlPdf`. El método `get_url_pdf()` contempla ambas variantes, y si se recorren los registros directamente conviene usar `.get()` para no depender del casing. El campo llega vacío mientras no se haya generado el PDF del comprobante.
 
 :pushpin: ***NOTA:*** Las pruebas unitarias de este servicio (`Test/test_storage.py`) requieren la variable de entorno `SDKTEST_UUID` con el UUID de un CFDI timbrado en la cuenta de pruebas, además de las ya conocidas `SDKTEST_USER`, `SDKTEST_PASSWORD` y `SDKTEST_TOKEN`.
 

--- a/README.md
+++ b/README.md
@@ -2087,7 +2087,7 @@ else:
 
 :pushpin: ***NOTA:*** El comprobante tarda alrededor de un minuto en quedar disponible en la consulta después de timbrarse. Durante ese lapso la respuesta es `success` con `records` vacío.
 
-:pushpin: ***NOTA:*** El campo con la url del PDF viene como `urlPDF`; el SDK de .NET lo nombra `urlPdf`. El método `get_url_pdf()` contempla ambas variantes, y si se recorren los registros directamente conviene usar `.get()` para no depender del casing. El campo llega vacío mientras no se haya generado el PDF del comprobante.
+:pushpin: ***NOTA:*** El campo con la url del PDF viene como `urlPDF`. El método `get_url_pdf()` contempla también la variante `urlPdf`, y si se recorren los registros directamente conviene usar `.get()` para no depender del casing. El campo llega vacío mientras no se haya generado el PDF del comprobante.
 
 :pushpin: ***NOTA:*** Las pruebas unitarias de este servicio (`Test/test_storage.py`) requieren la variable de entorno `SDKTEST_UUID` con el UUID de un CFDI timbrado en la cuenta de pruebas, además de las ya conocidas `SDKTEST_USER`, `SDKTEST_PASSWORD` y `SDKTEST_TOKEN`.
 

--- a/Storage/Storage.py
+++ b/Storage/Storage.py
@@ -1,0 +1,14 @@
+from Storage.StorageRequest import StorageRequest
+from Utils.Services import Services
+
+class Storage(Services):
+    urlApi = None
+    def __init__(self, url, urlApi, token = None, user = None, password = None):
+        super(Storage, self).__init__(url, token, user, password)
+        if urlApi:
+            self.urlApi = urlApi
+        else:
+            print("Debe especificar la urlApi")
+
+    def get_by_uuid(self, uuid):
+        return StorageRequest.get_by_uuid(self.urlApi, self.get_token(), uuid)

--- a/Storage/StorageRequest.py
+++ b/Storage/StorageRequest.py
@@ -1,0 +1,11 @@
+from Storage.StorageResponse import StorageResponse
+from Utils.requestHelper import RequestHelper
+
+class StorageRequest:
+    @staticmethod
+    def get_by_uuid(urlApi, token, uuid):
+        """Consulta un CFDI por su UUID. El formato del UUID no se valida en local:
+        se envía tal cual y responde el servicio."""
+        endpoint = f"{urlApi}/datawarehouse/v1/live/{str(uuid)}"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return StorageResponse(response)

--- a/Storage/StorageResponse.py
+++ b/Storage/StorageResponse.py
@@ -46,7 +46,7 @@ class StorageResponse(Response):
             return record.get("urlXml")
         return None
 
-    #La documentación oficial nombra el campo urlPDF y el SDK de .NET urlPdf.
+    #El servicio regresa el campo como urlPDF; se contempla urlPdf por si cambia el casing.
     def get_url_pdf(self):
         record = self.get_first_record()
         if record:

--- a/Storage/StorageResponse.py
+++ b/Storage/StorageResponse.py
@@ -1,0 +1,54 @@
+import json
+import traceback
+from Utils.response import Response
+class StorageResponse(Response):
+    def __init__(self, response):
+        try:
+            self.status_code = response.status_code
+            if(bool(response.text and response.text.strip())):
+                self.response = json.loads(response.text.encode().decode('utf8'))
+                if(self.status_code == 200):
+                    self.status = self.response["status"]
+                    self.data = self.response["data"]
+                else:
+                    if "status" in self.response:
+                        self.status = self.response["status"]
+                    self.message = self.response["message"]
+                    if "messageDetail" in self.response:
+                        self.messageDetail = self.response["messageDetail"]
+            else:
+                self.status = "error"
+                self.message = response.reason
+                self.messageDetail = response.request
+        except:
+            traceback.print_exc()
+
+    #Un UUID sin coincidencias regresa una lista vacía, no es un error.
+    def get_records(self):
+        if self.data:
+            return self.data.get("records") or []
+        return []
+
+    def get_metadata(self):
+        if self.data:
+            return self.data.get("metaData")
+        return None
+
+    def get_first_record(self):
+        records = self.get_records()
+        if records:
+            return records[0]
+        return None
+
+    def get_url_xml(self):
+        record = self.get_first_record()
+        if record:
+            return record.get("urlXml")
+        return None
+
+    #La documentación oficial nombra el campo urlPDF y el SDK de .NET urlPdf.
+    def get_url_pdf(self):
+        record = self.get_first_record()
+        if record:
+            return record.get("urlPdf") or record.get("urlPDF")
+        return None

--- a/Test/test_storage.py
+++ b/Test/test_storage.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import sys
+import uuid
 import requests
 
 #Función para poder importar módulos necesarios.
@@ -22,7 +23,15 @@ class TestStorage(unittest.TestCase):
         response = storage_obj.get_by_uuid(os.environ["SDKTEST_UUID"])
         self.assertTrue(self.expected == response.get_status())
         self.assertTrue(len(response.get_records()) > 0)
+        self.assertTrue(os.environ["SDKTEST_UUID"] == response.get_first_record()["uuid"])
         self.assertIsNotNone(response.get_url_xml(), "El valor de urlXml esta vacio")
+
+    def test_get_by_uuid_uuidObject(self):
+        #El UUID también se acepta como uuid.UUID, no sólo como cadena.
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = storage_obj.get_by_uuid(uuid.UUID(os.environ["SDKTEST_UUID"]))
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(os.environ["SDKTEST_UUID"] == response.get_first_record()["uuid"])
 
     def test_get_by_uuid_auth(self):
         storage_obj = Storage(TestStorage.url, TestStorage.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])

--- a/Test/test_storage.py
+++ b/Test/test_storage.py
@@ -18,6 +18,7 @@ class TestStorage(unittest.TestCase):
     uuidNotFound = "00000000-0000-0000-0000-000000000000"
     uuidInvalid = "no-es-uuid"
 
+    #UT Recuperación de XML por UUID
     def test_get_by_uuid(self):
         storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
         response = storage_obj.get_by_uuid(os.environ["SDKTEST_UUID"])
@@ -38,6 +39,7 @@ class TestStorage(unittest.TestCase):
         response = storage_obj.get_by_uuid(os.environ["SDKTEST_UUID"])
         self.assertTrue(self.expected == response.get_status())
 
+    #UT Consultas sin coincidencias
     def test_get_by_uuid_notFound(self):
         #Un UUID inexistente responde success con records vacío, no es un error.
         storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
@@ -55,6 +57,7 @@ class TestStorage(unittest.TestCase):
         self.assertTrue(self.expected == response.get_status())
         self.assertTrue(len(response.get_records()) == 0)
 
+    #UT de Error
     def test_get_by_uuid_emptyString(self):
         #Una cadena vacía deja la ruta en /datawarehouse/v1/live/, que es el buscador por
         #fechas: responde 400 pidiendo la fecha de inicio. No regresa un recurso distinto

--- a/Test/test_storage.py
+++ b/Test/test_storage.py
@@ -38,17 +38,23 @@ class TestStorage(unittest.TestCase):
         self.assertIsNone(response.get_url_xml())
 
     def test_get_by_uuid_invalidFormat(self):
-        #PENDIENTE DE VERIFICAR CONTRA EL AMBIENTE: no se pudo ejecutar la consulta con un
-        #UUID mal formado, así que se afirma únicamente el contrato común a las dos respuestas
-        #posibles (400 con message, o 200 con records vacío). Al correrla se fija la aserción exacta.
+        #Un UUID mal formado responde igual que uno inexistente: 200 success con records
+        #vacío y sin message. El servicio no valida el formato.
         storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
         response = storage_obj.get_by_uuid(TestStorage.uuidInvalid)
-        self.assertIsNotNone(response.get_status_code())
-        self.assertIn(response.get_status(), ("success", "error"))
-        if response.get_status() == "error":
-            self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
-        else:
-            self.assertTrue(len(response.get_records()) == 0)
+        self.assertTrue(200 == response.get_status_code())
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(len(response.get_records()) == 0)
+
+    def test_get_by_uuid_emptyString(self):
+        #Una cadena vacía deja la ruta en /datawarehouse/v1/live/, que es el buscador por
+        #fechas: responde 400 pidiendo la fecha de inicio. No regresa un recurso distinto
+        #al pedido, así que el valor se envía tal cual y responde el servicio.
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = storage_obj.get_by_uuid("")
+        self.assertTrue("error" == response.get_status())
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+        self.assertTrue(len(response.get_records()) == 0)
 
     def test_get_by_uuid_invalidToken(self):
         storage_obj = Storage(TestStorage.url, TestStorage.urlApi, "T2lYQ0t4.....")

--- a/Test/test_storage.py
+++ b/Test/test_storage.py
@@ -1,0 +1,69 @@
+import unittest
+import os
+import sys
+import requests
+
+#Función para poder importar módulos necesarios.
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+sys.path.append(PROJECT_ROOT)
+
+from Storage.Storage import Storage
+
+class TestStorage(unittest.TestCase):
+    expected = "success"
+    url = "https://services.test.sw.com.mx"
+    urlApi = "https://api.test.sw.com.mx"
+    #SDKTEST_UUID: UUID de un CFDI timbrado en la cuenta de pruebas, nunca de un cliente real.
+    uuidNotFound = "00000000-0000-0000-0000-000000000000"
+    uuidInvalid = "no-es-uuid"
+
+    def test_get_by_uuid(self):
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = storage_obj.get_by_uuid(os.environ["SDKTEST_UUID"])
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(len(response.get_records()) > 0)
+        self.assertIsNotNone(response.get_url_xml(), "El valor de urlXml esta vacio")
+
+    def test_get_by_uuid_auth(self):
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        response = storage_obj.get_by_uuid(os.environ["SDKTEST_UUID"])
+        self.assertTrue(self.expected == response.get_status())
+
+    def test_get_by_uuid_notFound(self):
+        #Un UUID inexistente responde success con records vacío, no es un error.
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = storage_obj.get_by_uuid(TestStorage.uuidNotFound)
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(len(response.get_records()) == 0)
+        self.assertIsNone(response.get_url_xml())
+
+    def test_get_by_uuid_invalidFormat(self):
+        #PENDIENTE DE VERIFICAR CONTRA EL AMBIENTE: no se pudo ejecutar la consulta con un
+        #UUID mal formado, así que se afirma únicamente el contrato común a las dos respuestas
+        #posibles (400 con message, o 200 con records vacío). Al correrla se fija la aserción exacta.
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = storage_obj.get_by_uuid(TestStorage.uuidInvalid)
+        self.assertIsNotNone(response.get_status_code())
+        self.assertIn(response.get_status(), ("success", "error"))
+        if response.get_status() == "error":
+            self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+        else:
+            self.assertTrue(len(response.get_records()) == 0)
+
+    def test_get_by_uuid_invalidToken(self):
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, "T2lYQ0t4.....")
+        response = storage_obj.get_by_uuid(TestStorage.uuidNotFound)
+        self.assertTrue("error" == response.get_status())
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+
+    def test_get_by_uuid_withoutUrlApi(self):
+        #Con urlApi vacía la librería avisa por consola igual que Pdf y AccountUser, y la
+        #petición no se puede armar. Se documenta el comportamiento actual del repositorio.
+        storage_obj = Storage(TestStorage.url, "", os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(requests.exceptions.RequestException):
+            storage_obj.get_by_uuid(TestStorage.uuidNotFound)
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestStorage)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 setuptools.setup(
     name='sw-sdk-python',
-    version='0.0.9.1',
+    version='0.0.10.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
     packages=setuptools.find_packages(

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ setuptools.setup(
     version='0.0.10.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
-    packages=setuptools.find_packages(
-    license="MIT",),
+    packages=setuptools.find_packages(),
+    license="MIT",
     long_description_content_type="text/markdown",
     long_description=open('README.md',encoding='utf-8').read(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
 )


### PR DESCRIPTION
### Actividad

SS-271 – Actualización librerías – Recuperar XML por UUID – Python

### Qué incluye

- Paquete `Storage/` nuevo, que la librería no exponía: `__init__.py`, `Storage.py`, `StorageRequest.py` y `StorageResponse.py`, con el patrón de 3 archivos del repositorio
- `get_by_uuid(uuid)` – recupera la información y las URLs de descarga de un CFDI timbrado con SW (GET `/datawarehouse/v1/live/{uuid}`). Acepta el UUID como `str` o como `uuid.UUID`
- Getters de conveniencia en `StorageResponse` que no revientan con `records` vacío: `get_records()`, `get_metadata()`, `get_first_record()`, `get_url_xml()` y `get_url_pdf()`, este último contemplando `urlPDF` y `urlPdf`
- Sin validación local del UUID: el valor se envía tal cual y responde el servicio con su contrato de error, conforme a lo acordado en la revisión de SS-269
- Sección `## Recuperar XML por UUID ##` del README, entre `## Certificados ##` y `## TimbradoV4 ##`, con 2 bloques y 2 ejemplos, y las notas de que un UUID no encontrado regresa `success` con `records` vacío y de que la url base es la de la API
- Pruebas unitarias de los 7 escenarios, todas contra el ambiente de test: consulta por token, por usuario y contraseña, UUID inexistente, UUID mal formado, cadena vacía, token inválido y `urlApi` vacía
- Las pruebas requieren la variable de entorno `SDKTEST_UUID`, con el UUID de un CFDI timbrado en la cuenta de pruebas, además de las ya conocidas `SDKTEST_USER`, `SDKTEST_PASSWORD` y `SDKTEST_TOKEN`. La comparte la subtarea de Regenerar PDF

### Versión

0.0.9.1 → 0.0.10.1 (feature: se agrega funcionalidad)

### Criterios de aceptación

- [x] Se permite la recuperación de un XML con base en el UUID proporcionado
- [x] UTs en success
- [x] Documentación y ejemplos en el README