### PR TITLE
Feature/ss 275

### DIFF
--- a/Pdf/Pdf.py
+++ b/Pdf/Pdf.py
@@ -12,5 +12,11 @@ class Pdf(Services):
     
     def generate_pdf(self,xml, b64Logo, template_id, extras):
         return PdfRequest.generate_pdf(self.urlApi, self.get_token(),xml, b64Logo, template_id, extras)
-    
+
+    def regenerate_pdf(self, uuid, b64Logo=None, template_id=None, extras=None):
+        """Regenera el PDF de un comprobante previamente timbrado y lo guarda o
+        reemplaza en el Administrador de Timbres. El uuid se acepta como cadena o
+        como uuid.UUID."""
+        return PdfRequest.regenerate_pdf(self.urlApi, self.get_token(), uuid, b64Logo, template_id, extras)
+
     

--- a/Pdf/Pdf.py
+++ b/Pdf/Pdf.py
@@ -14,9 +14,6 @@ class Pdf(Services):
         return PdfRequest.generate_pdf(self.urlApi, self.get_token(),xml, b64Logo, template_id, extras)
 
     def regenerate_pdf(self, uuid, b64Logo=None, template_id=None, extras=None):
-        """Regenera el PDF de un comprobante previamente timbrado y lo guarda o
-        reemplaza en el Administrador de Timbres. El uuid se acepta como cadena o
-        como uuid.UUID."""
         return PdfRequest.regenerate_pdf(self.urlApi, self.get_token(), uuid, b64Logo, template_id, extras)
 
     

--- a/Pdf/PdfRequest.py
+++ b/Pdf/PdfRequest.py
@@ -1,4 +1,5 @@
 from Pdf.PdfResponse import PdfResponse
+from Pdf.RegeneratePdfResponse import RegeneratePdfResponse
 from Utils.requestHelper import RequestHelper
 
 class PdfRequest():
@@ -8,4 +9,19 @@ class PdfRequest():
         endpoint = urlApi + "/pdf/v1/api/GeneratePdf"
         response = RequestHelper.post_json_request(endpoint,token,payload)
         return PdfResponse(response)
-    
+
+    @staticmethod
+    def regenerate_pdf(urlApi, token, uuid, b64Logo=None, template_id=None, extras=None):
+        """Regenera el PDF de un comprobante timbrado y lo reemplaza en el ADT.
+        Todos los datos del cuerpo son opcionales: sólo se envían los informados.
+        El formato del UUID no se valida en local, se envía tal cual y responde el servicio."""
+        payload = {}
+        if b64Logo is not None:
+            payload['logo'] = b64Logo
+        if template_id is not None:
+            payload['templateId'] = template_id
+        if extras is not None:
+            payload['extras'] = extras
+        endpoint = urlApi + "/pdf/v1/api/RegeneratePdf/" + str(uuid)
+        response = RequestHelper.post_json_request(endpoint,token,payload)
+        return RegeneratePdfResponse(response)

--- a/Pdf/PdfRequest.py
+++ b/Pdf/PdfRequest.py
@@ -12,9 +12,6 @@ class PdfRequest():
 
     @staticmethod
     def regenerate_pdf(urlApi, token, uuid, b64Logo=None, template_id=None, extras=None):
-        """Regenera el PDF de un comprobante timbrado y lo reemplaza en el ADT.
-        Todos los datos del cuerpo son opcionales: sólo se envían los informados.
-        El formato del UUID no se valida en local, se envía tal cual y responde el servicio."""
         payload = {}
         if b64Logo is not None:
             payload['logo'] = b64Logo

--- a/Pdf/RegeneratePdfResponse.py
+++ b/Pdf/RegeneratePdfResponse.py
@@ -2,8 +2,6 @@ import json
 import traceback
 from Utils.response import Response
 
-#La regeneración de PDF sólo regresa un mensaje: la respuesta no trae las llaves
-#status ni data, por eso no puede reutilizar PdfResponse.
 class RegeneratePdfResponse(Response):
     def __init__(self, response):
         try:
@@ -17,7 +15,6 @@ class RegeneratePdfResponse(Response):
                     if "messageDetail" in self.response:
                         self.messageDetail = self.response["messageDetail"]
                 except ValueError:
-                    #Un cuerpo que no es JSON se conserva tal cual en message.
                     self.message = response.text
             else:
                 self.message = response.reason

--- a/Pdf/RegeneratePdfResponse.py
+++ b/Pdf/RegeneratePdfResponse.py
@@ -1,0 +1,25 @@
+import json
+import traceback
+from Utils.response import Response
+
+#La regeneración de PDF sólo regresa un mensaje: la respuesta no trae las llaves
+#status ni data, por eso no puede reutilizar PdfResponse.
+class RegeneratePdfResponse(Response):
+    def __init__(self, response):
+        try:
+            self.status_code = response.status_code
+            self.status = "success" if self.status_code == 200 else "error"
+            if(bool(response.text and response.text.strip())):
+                try:
+                    self.response = json.loads(response.text.encode().decode('utf8'))
+                    if "message" in self.response:
+                        self.message = self.response["message"]
+                    if "messageDetail" in self.response:
+                        self.messageDetail = self.response["messageDetail"]
+                except ValueError:
+                    #Un cuerpo que no es JSON se conserva tal cual en message.
+                    self.message = response.text
+            else:
+                self.message = response.reason
+        except:
+            traceback.print_exc()

--- a/README.md
+++ b/README.md
@@ -1675,6 +1675,56 @@ f.close()
 Para mayor referencia de estas plantillas de PDF, favor de visitar el siguiente [link](https://developers.sw.com.mx/knowledge-base/plantillas-pdf/).
 </details>
 
+<details>
+<summary>
+Regenerar PDF
+</summary>
+
+Este método genera o regenera el PDF de un CFDI previamente timbrado y lo guarda o reemplaza en el Administrador de Timbres. Puede ser consumido ingresando tu usuario y contraseña así como tambien ingresando solo el token. Este método recibe los siguientes parámetros:
+
+* Url servicios SW
+* Url Api
+* Usuario y contraseña o Token
+* UUID del CFDI, como cadena o como `uuid.UUID`
+* Logo en base 64 (opcional)
+* Template id (opcional), se solicita a Soporte Técnico cuando se trata de una plantilla personalizada
+* Datos extra (opcional), sólo aplica en plantillas personalizadas
+
+**Ejemplo de consumo de la libreria para la regeneración de PDF mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Pdf.Pdf import Pdf
+
+pdf = Pdf("https://services.test.sw.com.mx","https://api.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
+response = pdf.regenerate_pdf("d3773788-c68a-4549-ac67-f223d26c925b")
+
+if response.get_status() == "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	print(response.get_status())
+	print(response.get_message())
+```
+
+**Ejemplo de consumo de la libreria para la regeneración de PDF mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Pdf.Pdf import Pdf
+
+#Datos opcionales para una plantilla personalizada
+logo = None
+extras = {
+        'REFERENCIA': "Referencia de pruebas"
+        }
+pdf = Pdf("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, "user", "password")
+response = pdf.regenerate_pdf("d3773788-c68a-4549-ac67-f223d26c925b", logo, "cfdi40", extras)
+print(response.get_status())
+print(response.get_message())
+```
+
+:pushpin: ***NOTA:*** Este servicio no devuelve el PDF en base 64, únicamente el mensaje de confirmación, y el archivo queda almacenado o reemplazado en el Administrador de Timbres. Si se necesita el contenido del PDF en la respuesta, el servicio correspondiente es **Generar PDF**; las URLs de descarga del comprobante ya regenerado se obtienen con [Recuperar XML por UUID](#recuperar-xml-por-uuid).
+</details>
+
 ## Certificados ##
 Servicio para gestionar los certificados CSD de tu cuenta.
 Para administrar los certificados de manera gráfica, puede hacerlo desde el [Administrador de timbres](https://portal.sw.com.mx/).

--- a/Test/test_pdf.py
+++ b/Test/test_pdf.py
@@ -1,6 +1,8 @@
 import unittest
-import os 
+import os
 import sys
+import time
+import uuid
 from base64 import b64decode
 
 #Función para poder importar módulos necesarios.
@@ -10,11 +12,23 @@ sys.path.append(PROJECT_ROOT)
 from Pdf.Pdf import Pdf
 
 class TestPdf(unittest.TestCase):
+    url = "https://services.test.sw.com.mx"
+    urlApi = "https://api.test.sw.com.mx"
+    #SDKTEST_UUID: UUID de un CFDI timbrado en la cuenta de pruebas, nunca de un cliente real.
+    uuidNotFound = "00000000-0000-0000-0000-000000000000"
+    uuidInvalid = "no-es-uuid"
+
     @staticmethod
     def open_file(pathFile):
         out = open(pathFile,"r", encoding='latin_1', errors='ignore').read()
         return out
     
+    @staticmethod
+    def esperar_limite():
+        #La regeneración limita el número de peticiones por usuario y responde 429 si se
+        #consumen seguidas: se espacian para no depender del ritmo de la suite.
+        time.sleep(3)
+
     @staticmethod
     def save_pdf(contentB64):
         bytes = b64decode(contentB64, validate=True)
@@ -90,5 +104,72 @@ class TestPdf(unittest.TestCase):
             print (Key,"=",Value)
         TestPdf.save_pdf(response.data['contentB64'])
 
-suite = unittest.TestLoader().loadTestsFromTestCase(TestPdf)
-unittest.TextTestRunner(verbosity=2).run(suite)
+    #UT Regeneración de PDF
+    def test_regenerate_pdf_token(self):
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        self.assertTrue(response.get_status() == "success")
+        self.assertTrue(200 == response.get_status_code())
+        self.assertIn("correctamente", response.get_message())
+
+    def test_regenerate_pdf_auth(self):
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
+        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        self.assertTrue(response.get_status() == "success")
+
+    def test_regenerate_pdf_uuidObject(self):
+        #El UUID también se acepta como uuid.UUID, no sólo como cadena.
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf(uuid.UUID(os.environ['SDKTEST_UUID']))
+        self.assertTrue(response.get_status() == "success")
+
+    def test_regenerate_pdf_template_extras(self):
+        #Los datos extra viajan anidados en extras, igual que en la generación de PDF.
+        extras = {
+            'REFERENCIA': "Referencia de pruebas"
+        }
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'], None, "cfdi40", extras)
+        self.assertTrue(response.get_status() == "success")
+
+    #UT de Error
+    def test_regenerate_pdf_notFound(self):
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf(TestPdf.uuidNotFound)
+        self.assertTrue(response.get_status() == "error")
+        self.assertTrue(404 == response.get_status_code())
+        self.assertIn("UUID", response.get_message())
+
+    def test_regenerate_pdf_invalidFormat(self):
+        #Un UUID mal formado responde igual que uno inexistente: 404 con el mensaje del
+        #servicio. El formato no se valida en local.
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf(TestPdf.uuidInvalid)
+        self.assertTrue(response.get_status() == "error")
+        self.assertTrue(404 == response.get_status_code())
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+
+    def test_regenerate_pdf_emptyString(self):
+        #Una cadena vacía deja la ruta en /pdf/v1/api/RegeneratePdf/, que no existe: responde
+        #404 y no un recurso distinto al pedido, así que el valor se envía tal cual.
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf("")
+        self.assertTrue(response.get_status() == "error")
+        self.assertTrue(404 == response.get_status_code())
+
+    def test_regenerate_pdf_invalidToken(self):
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, "T2lYQ0t4.....")
+        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        self.assertTrue(response.get_status() == "error")
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestPdf)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/Test/test_pdf.py
+++ b/Test/test_pdf.py
@@ -14,6 +14,7 @@ from Pdf.Pdf import Pdf
 class TestPdf(unittest.TestCase):
     url = "https://services.test.sw.com.mx"
     urlApi = "https://api.test.sw.com.mx"
+    uuidTest = "3001449c-ef91-4bd5-a698-687bdea46414"
     uuidNotFound = "00000000-0000-0000-0000-000000000000"
     uuidInvalid = "no-es-uuid"
 
@@ -106,7 +107,7 @@ class TestPdf(unittest.TestCase):
     def test_regenerate_pdf_token(self):
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
-        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        response = pdf.regenerate_pdf(TestPdf.uuidTest)
         self.assertTrue(response.get_status() == "success")
         self.assertTrue(200 == response.get_status_code())
         self.assertIn("correctamente", response.get_message())
@@ -114,13 +115,13 @@ class TestPdf(unittest.TestCase):
     def test_regenerate_pdf_auth(self):
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        response = pdf.regenerate_pdf(TestPdf.uuidTest)
         self.assertTrue(response.get_status() == "success")
 
     def test_regenerate_pdf_uuidObject(self):
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
-        response = pdf.regenerate_pdf(uuid.UUID(os.environ['SDKTEST_UUID']))
+        response = pdf.regenerate_pdf(uuid.UUID(TestPdf.uuidTest))
         self.assertTrue(response.get_status() == "success")
 
     def test_regenerate_pdf_template_extras(self):
@@ -129,7 +130,7 @@ class TestPdf(unittest.TestCase):
         }
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
-        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'], None, "cfdi40", extras)
+        response = pdf.regenerate_pdf(TestPdf.uuidTest, None, "cfdi40", extras)
         self.assertTrue(response.get_status() == "success")
 
     #UT de Error
@@ -157,7 +158,7 @@ class TestPdf(unittest.TestCase):
 
     def test_regenerate_pdf_invalidToken(self):
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, "T2lYQ0t4.....")
-        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        response = pdf.regenerate_pdf(TestPdf.uuidTest)
         self.assertTrue(response.get_status() == "error")
         self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
 

--- a/Test/test_pdf.py
+++ b/Test/test_pdf.py
@@ -14,7 +14,6 @@ from Pdf.Pdf import Pdf
 class TestPdf(unittest.TestCase):
     url = "https://services.test.sw.com.mx"
     urlApi = "https://api.test.sw.com.mx"
-    #SDKTEST_UUID: UUID de un CFDI timbrado en la cuenta de pruebas, nunca de un cliente real.
     uuidNotFound = "00000000-0000-0000-0000-000000000000"
     uuidInvalid = "no-es-uuid"
 
@@ -25,8 +24,7 @@ class TestPdf(unittest.TestCase):
     
     @staticmethod
     def esperar_limite():
-        #La regeneración limita el número de peticiones por usuario y responde 429 si se
-        #consumen seguidas: se espacian para no depender del ritmo de la suite.
+        #La regeneración responde 429 cuando se consumen varias peticiones seguidas.
         time.sleep(3)
 
     @staticmethod
@@ -120,14 +118,12 @@ class TestPdf(unittest.TestCase):
         self.assertTrue(response.get_status() == "success")
 
     def test_regenerate_pdf_uuidObject(self):
-        #El UUID también se acepta como uuid.UUID, no sólo como cadena.
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
         response = pdf.regenerate_pdf(uuid.UUID(os.environ['SDKTEST_UUID']))
         self.assertTrue(response.get_status() == "success")
 
     def test_regenerate_pdf_template_extras(self):
-        #Los datos extra viajan anidados en extras, igual que en la generación de PDF.
         extras = {
             'REFERENCIA': "Referencia de pruebas"
         }
@@ -146,8 +142,6 @@ class TestPdf(unittest.TestCase):
         self.assertIn("UUID", response.get_message())
 
     def test_regenerate_pdf_invalidFormat(self):
-        #Un UUID mal formado responde igual que uno inexistente: 404 con el mensaje del
-        #servicio. El formato no se valida en local.
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
         response = pdf.regenerate_pdf(TestPdf.uuidInvalid)
@@ -156,8 +150,6 @@ class TestPdf(unittest.TestCase):
         self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
 
     def test_regenerate_pdf_emptyString(self):
-        #Una cadena vacía deja la ruta en /pdf/v1/api/RegeneratePdf/, que no existe: responde
-        #404 y no un recurso distinto al pedido, así que el valor se envía tal cual.
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
         response = pdf.regenerate_pdf("")
         self.assertTrue(response.get_status() == "error")

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 setuptools.setup(
     name='sw-sdk-python',
-    version='0.0.10.1',
+    version='0.0.11.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
### Actividad

SS-275 – Actualización librerías – Regenerar PDF – Python

### Qué incluye

- Servicio `regenerate_pdf` en `Pdf`, que genera o regenera el PDF de un CFDI previamente timbrado y lo guarda o reemplaza en el Administrador de Timbres.
- `Pdf/RegeneratePdfResponse.py`, clase de respuesta propia del servicio. `PdfResponse` y `generate_pdf` quedan sin cambios.
- Los datos del cuerpo (`logo`, `templateId` y `extras`) son opcionales y sólo se envían cuando vienen informados.
- El UUID se acepta como cadena o como `uuid.UUID`.
- Ocho pruebas unitarias en `Test/test_pdf.py`: regeneración con token, con usuario y contraseña, con plantilla y datos extra, y los casos de error de UUID inexistente, UUID mal formado, cadena vacía y token inválido. Usan `SDKTEST_UUID`, la misma variable que ya emplea `Test/test_storage.py`.
- Documentación y ejemplos de Regenerar PDF en la sección `## PDF ##` del README.

### Versión

`0.0.10.1` → `0.0.11.1` (feature: se agrega funcionalidad)

### Criterios de aceptación

- [x] La librería cuenta con el servicio de regeneración de PDF
- [x] UTs en success
- [x] Documentación y ejemplos en el README