### PR TITLE
Feature/ss 274

### DIFF
--- a/Issue/IssueRequestV4.py
+++ b/Issue/IssueRequestV4.py
@@ -5,28 +5,41 @@ from typing import Optional, Dict, Union
 
 class IssueRequestV4:
     @staticmethod
-   
-    def issue_xml(url: str, token: str, xml: str, headers: Optional[Dict], version: ResponseVersion) -> IssueResponse:
-        """ Método estático para timbrar usando el servicio Emisión Timbrado XML V4 con soporte de versiones de respuesta."""
-        path = f"/v4/cfdi33/issue/{str(version)}"
+    def _build_headers(headers: Optional[Dict], email, custom_id: str, pdf: bool) -> Dict:
+        request_headers = {}
+        if email:
+            request_headers['email'] = ",".join(email) if isinstance(email, list) else email
+        if custom_id:
+            request_headers['customid'] = custom_id
+        if pdf:
+            request_headers['extra'] = "pdf"
+        if headers:
+            request_headers.update(headers)
+        return request_headers
+
+    @staticmethod
+    def issue_xml(url: str, token: str, xml: str, headers: Optional[Dict], version: ResponseVersion,
+                  email=None, custom_id: str = None, pdf: bool = False, b64: bool = False) -> IssueResponse:
+        bs64 = "/b64" if b64 else ""
+        path = f"/v4/cfdi33/issue/{str(version)}{bs64}"
         complete_url = f"{url}{path}"
         response = RequestHelper.post_v4(
             endpoint=complete_url,
             content=xml,
             token=token,
-            headers=headers
+            headers=IssueRequestV4._build_headers(headers, email, custom_id, pdf)
         )
         return IssueResponse(response)
 
     @staticmethod
-    def issue_json(url: str, token: str, json_data: Union[str, dict], headers: Optional[Dict], version: ResponseVersion) -> IssueResponse:
-        """" Método estático para timbrar usando el servicio Emisión Timbrado JSON V4 con soporte de versiones de respuesta."""
+    def issue_json(url: str, token: str, json_data: Union[str, dict], headers: Optional[Dict], version: ResponseVersion,
+                   email=None, custom_id: str = None, pdf: bool = False) -> IssueResponse:
         path = f"/v4/cfdi33/issue/json/{str(version)}"
         complete_url = f"{url}{path}"
         response = RequestHelper.post_v4_json(
             endpoint=complete_url,
             content=json_data,
             token=token,
-            headers=headers
+            headers=IssueRequestV4._build_headers(headers, email, custom_id, pdf)
         )
         return IssueResponse(response)

--- a/Issue/IssueV4.py
+++ b/Issue/IssueV4.py
@@ -8,20 +8,29 @@ class IssueV4(Services):
     def __init__(self, url: str, token: str = None, user: str = None, password: str = None):
         super(IssueV4, self).__init__(url, token, user, password)
 
-    def issue_xml(self, xml: str, headers: Optional[Dict] = None, version: ResponseVersion = ResponseVersion.V1) -> IssueResponse:
+    def issue_xml(self, xml: str, headers: Optional[Dict] = None, version: ResponseVersion = ResponseVersion.V1,
+                  email=None, custom_id: str = None, pdf: bool = False, b64: bool = False) -> IssueResponse:
         return IssueRequestV4.issue_xml(
             url=self.get_url(),
             token=self.get_token(),
             xml=xml,
             headers=headers,
-            version=version
+            version=version,
+            email=email,
+            custom_id=custom_id,
+            pdf=pdf,
+            b64=b64
         )
 
-    def issue_json(self, json_data: Union[str, dict], headers: Optional[Dict] = None, version: ResponseVersion = ResponseVersion.V1) -> IssueResponse:
+    def issue_json(self, json_data: Union[str, dict], headers: Optional[Dict] = None, version: ResponseVersion = ResponseVersion.V1,
+                   email=None, custom_id: str = None, pdf: bool = False) -> IssueResponse:
         return IssueRequestV4.issue_json(
             url=self.get_url(),
             token=self.get_token(),
             json_data=json_data,
             headers=headers,
-            version=version
+            version=version,
+            email=email,
+            custom_id=custom_id,
+            pdf=pdf
         )

--- a/README.md
+++ b/README.md
@@ -2177,7 +2177,6 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-#El listado de correos tambien se acepta como lista
 response = issue.issue_xml(xml_content, email=["test1@test.com", "test2@test.com"], version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
@@ -2316,8 +2315,6 @@ print(response.get_data())
 print(response.get_status())
 ```
 </details>
-
-:pushpin: ***NOTA:*** El PDF no viene en la respuesta del timbrado: se guarda en el ADT y su URL de descarga se obtiene con [Recuperar XML por UUID](#recuperar-xml-por-uuid). Si necesita el contenido del PDF en la respuesta, el servicio correspondiente es [Generar PDF](#pdf).
 
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -2133,6 +2133,15 @@ else:
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.
 
+Los tres métodos (`StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`) reciben los mismos parámetros opcionales:
+
+* `email`: uno o varios correos a los que se enviará el XML timbrado, como cadena separada por comas o como lista.
+* `custom_id`: identificador asignado por el usuario para evitar la duplicidad de timbrado.
+* `pdf`: con el valor `True` confirma la generación del PDF, que se guarda en automático en el ADT.
+* `b64`: con el valor `True` indica que el XML se envía en base 64. No aplica en `issue_json`.
+* `headers`: diccionario de headers, que se sigue recibiendo. Sus valores prevalecen sobre los parámetros anteriores.
+* `version`: versión de la respuesta, tomada del enum `ResponseVersion` (`V1`, `V2`, `V3` y `V4`). Puede consultar el detalle de cada versión en el siguiente [link](https://developers.sw.com.mx/knowledge-base/versiones-de-respuesta-timbrado/).
+
 ### **Email** ###
 
 Este servicio recibe un comprobante CFDI para ser timbrado y recibe un listado de uno o hasta 5 correos electrónicos a los que se requiera enviar el XML timbrado.
@@ -2146,14 +2155,12 @@ Existen varias versiones de respuesta a este método, las cuales puede consultar
 ```py
 from Stamp.StampV4 import StampV4
 from Utils.response_version import ResponseVersion
+
 #Creamos funcion para abrir nuestro archivo
- xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
- stamp = StampV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
- headers = {
-                "email": "stamp1@test.com,stamp2@test.com"
-           }
-response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
+stamp = StampV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
+response = stamp.stamp(xml_content, email="stamp1@test.com,stamp2@test.com", version=ResponseVersion.V2)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2167,16 +2174,13 @@ print(response.get_status())
 ```py
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
-issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
-             xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-            
-           headers = {
-                "email": "test1@test.com,test2@test.com"
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            print(response.get_data())
-            print(response.get_status())
+
+issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+#El listado de correos tambien se acepta como lista
+response = issue.issue_xml(xml_content, email=["test1@test.com", "test2@test.com"], version=ResponseVersion.V4)
+print(response.get_data())
+print(response.get_status())
 ```
 
 </details>
@@ -2189,16 +2193,11 @@ issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealT
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
 
-            issue = IssueV4("http://services.test.sw.com.mx", None, "user", "password")
-            json_content =  open_file("cfdi.json")
-            
-            headers = {
-                "email": "test1@test.com,test2@test.com"
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
-            print(response.get_data())
-            print(response.get_status())
+issue = IssueV4("https://services.test.sw.com.mx", None, "user", "password")
+json_content = open("cfdi.json", "r", encoding='utf-8').read()
+response = issue.issue_json(json_content, email="test1@test.com,test2@test.com", version=ResponseVersion.V4)
+print(response.get_data())
+print(response.get_status())
 ```
 </details>
 
@@ -2215,14 +2214,12 @@ Existen varias versiones de respuesta a este método, las cuales puede consultar
 ```py
 from Stamp.StampV4 import StampV4
 from Utils.response_version import ResponseVersion
+
 #Creamos funcion para abrir nuestro archivo
- xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
- stamp = StampV4("http://services.test.sw.com.mx",None, "user", "password")
- headers = {
-                 "customid": "ISS-25-369"
-           }
-response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V3)
+stamp = StampV4("https://services.test.sw.com.mx",None, "user", "password")
+response = stamp.stamp(xml_content, custom_id="ISS-25-369", version=ResponseVersion.V3)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2235,16 +2232,12 @@ print(response.get_status())
 ```py
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
-issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
-             xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-            
-           headers = {
-                  "customid": "ISS-25-368"
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            print(response.get_data())
-            print(response.get_status())
+
+issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+response = issue.issue_xml(xml_content, custom_id="ISS-25-368", version=ResponseVersion.V4)
+print(response.get_data())
+print(response.get_status())
 ```
 
 </details>
@@ -2257,16 +2250,11 @@ issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealT
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
 
-            issue = IssueV4("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
-            json_content =  open_file("cfdi.json")
-            
-            headers = {
-                  "customid": "ISS-25-369"
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V1)
-            print(response.get_data())
-            print(response.get_status())
+issue = IssueV4("https://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+json_content = open("cfdi.json", "r", encoding='utf-8').read()
+response = issue.issue_json(json_content, custom_id="ISS-25-369", version=ResponseVersion.V1)
+print(response.get_data())
+print(response.get_status())
 ```
 </details>
 
@@ -2284,14 +2272,12 @@ Existen varias versiones de respuesta a este método, las cuales puede consultar
 ```py
 from Stamp.StampV4 import StampV4
 from Utils.response_version import ResponseVersion
+
 #Creamos funcion para abrir nuestro archivo
- xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
- stamp = StampV4("http://services.test.sw.com.mx",None, "user", "password")
- headers = {
-                 "pdf": "true"
-           }
-response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
+stamp = StampV4("https://services.test.sw.com.mx",None, "user", "password")
+response = stamp.stamp(xml_content, pdf=True, version=ResponseVersion.V2)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2304,16 +2290,12 @@ print(response.get_status())
 ```py
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
-issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
-             xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-            
-           headers = {
-                   "pdf": "true"
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            print(response.get_data())
-            print(response.get_status())
+
+issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+response = issue.issue_xml(xml_content, pdf=True, version=ResponseVersion.V4)
+print(response.get_data())
+print(response.get_status())
 ```
 
 </details>
@@ -2327,18 +2309,15 @@ issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealT
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
 
-            issue = IssueV4("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
-            json_content =  open_file("cfdi.json")
-            
-            headers = {
-                  "pdf": "true"
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
-            print(response.get_data())
-            print(response.get_status())
+issue = IssueV4("https://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+json_content = open("cfdi.json", "r", encoding='utf-8').read()
+response = issue.issue_json(json_content, pdf=True, version=ResponseVersion.V4)
+print(response.get_data())
+print(response.get_status())
 ```
 </details>
+
+:pushpin: ***NOTA:*** El PDF no viene en la respuesta del timbrado: se guarda en el ADT y su URL de descarga se obtiene con [Recuperar XML por UUID](#recuperar-xml-por-uuid). Si necesita el contenido del PDF en la respuesta, el servicio correspondiente es [Generar PDF](#pdf).
 
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -2133,13 +2133,17 @@ else:
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.
 
-Los tres métodos (`StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`) reciben los mismos parámetros opcionales:
+Los tres métodos (`StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`) reciben los headers en el parámetro `headers` y esa es la forma de consumo de referencia, la que usan los ejemplos de esta sección: los nombres de los headers se documentan aquí, de modo que si el servicio agrega o cambia alguno basta con actualizar esta documentación. Los headers disponibles son:
 
-* `email`: uno o varios correos a los que se enviará el XML timbrado, como cadena separada por comas o como lista.
-* `custom_id`: identificador asignado por el usuario para evitar la duplicidad de timbrado.
-* `pdf`: con el valor `True` confirma la generación del PDF, que se guarda en automático en el ADT.
+* `email`: uno o varios correos, separados por comas, a los que se enviará el XML timbrado.
+* `customid`: identificador asignado por el usuario para evitar la duplicidad de timbrado.
+* `extra`: con el valor `pdf` confirma la generación del PDF, que se guarda en automático en el ADT.
+
+Como atajo para esos tres headers, los mismos métodos aceptan los parámetros `email`, `custom_id` y `pdf`, que los arman internamente; `email` acepta también una lista y `pdf` es un booleano. Si se envían las dos formas al mismo tiempo, prevalece el contenido de `headers`.
+
+Los tres métodos reciben además:
+
 * `b64`: con el valor `True` indica que el XML se envía en base 64. No aplica en `issue_json`.
-* `headers`: diccionario de headers, que se sigue recibiendo. Sus valores prevalecen sobre los parámetros anteriores.
 * `version`: versión de la respuesta, tomada del enum `ResponseVersion` (`V1`, `V2`, `V3` y `V4`). Puede consultar el detalle de cada versión en el siguiente [link](https://developers.sw.com.mx/knowledge-base/versiones-de-respuesta-timbrado/).
 
 ### **Email** ###
@@ -2160,7 +2164,10 @@ from Utils.response_version import ResponseVersion
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
 stamp = StampV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
-response = stamp.stamp(xml_content, email="stamp1@test.com,stamp2@test.com", version=ResponseVersion.V2)
+headers = {
+    "email": "stamp1@test.com,stamp2@test.com"
+}
+response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2177,7 +2184,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-response = issue.issue_xml(xml_content, email=["test1@test.com", "test2@test.com"], version=ResponseVersion.V4)
+headers = {
+    "email": "test1@test.com,test2@test.com"
+}
+response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2194,7 +2204,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx", None, "user", "password")
 json_content = open("cfdi.json", "r", encoding='utf-8').read()
-response = issue.issue_json(json_content, email="test1@test.com,test2@test.com", version=ResponseVersion.V4)
+headers = {
+    "email": "test1@test.com,test2@test.com"
+}
+response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2218,7 +2231,10 @@ from Utils.response_version import ResponseVersion
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
 stamp = StampV4("https://services.test.sw.com.mx",None, "user", "password")
-response = stamp.stamp(xml_content, custom_id="ISS-25-369", version=ResponseVersion.V3)
+headers = {
+    "customid": "ISS-25-369"
+}
+response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V3)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2234,7 +2250,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-response = issue.issue_xml(xml_content, custom_id="ISS-25-368", version=ResponseVersion.V4)
+headers = {
+    "customid": "ISS-25-368"
+}
+response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2251,7 +2270,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
 json_content = open("cfdi.json", "r", encoding='utf-8').read()
-response = issue.issue_json(json_content, custom_id="ISS-25-369", version=ResponseVersion.V1)
+headers = {
+    "customid": "ISS-25-369"
+}
+response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V1)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2276,7 +2298,10 @@ from Utils.response_version import ResponseVersion
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
 stamp = StampV4("https://services.test.sw.com.mx",None, "user", "password")
-response = stamp.stamp(xml_content, pdf=True, version=ResponseVersion.V2)
+headers = {
+    "extra": "pdf"
+}
+response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2292,7 +2317,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-response = issue.issue_xml(xml_content, pdf=True, version=ResponseVersion.V4)
+headers = {
+    "extra": "pdf"
+}
+response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2310,7 +2338,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
 json_content = open("cfdi.json", "r", encoding='utf-8').read()
-response = issue.issue_json(json_content, pdf=True, version=ResponseVersion.V4)
+headers = {
+    "extra": "pdf"
+}
+response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
 ```

--- a/README.md
+++ b/README.md
@@ -2133,13 +2133,13 @@ else:
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.
 
-Los tres métodos (`StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`) reciben los headers en el parámetro `headers` y esa es la forma de consumo de referencia, la que usan los ejemplos de esta sección: los nombres de los headers se documentan aquí, de modo que si el servicio agrega o cambia alguno basta con actualizar esta documentación. Los headers disponibles son:
+Los tres métodos (`StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`) reciben los headers en el parámetro `headers`. Los headers disponibles son:
 
-* `email`: uno o varios correos, separados por comas, a los que se enviará el XML timbrado.
+* `email`: hasta 5 correos, separados por comas, a los que se enviará el XML timbrado.
 * `customid`: identificador asignado por el usuario para evitar la duplicidad de timbrado.
 * `extra`: con el valor `pdf` confirma la generación del PDF, que se guarda en automático en el ADT.
 
-Como atajo para esos tres headers, los mismos métodos aceptan los parámetros `email`, `custom_id` y `pdf`, que los arman internamente; `email` acepta también una lista y `pdf` es un booleano. Si se envían las dos formas al mismo tiempo, prevalece el contenido de `headers`.
+Esos tres headers también se pueden enviar con los parámetros `email`, `custom_id` y `pdf`, que los arman internamente; `email` acepta además una lista y `pdf` es un booleano. Si se usan las dos formas al mismo tiempo, prevalece el contenido de `headers`.
 
 Los tres métodos reciben además:
 

--- a/Stamp/StampRequestV4.py
+++ b/Stamp/StampRequestV4.py
@@ -4,16 +4,28 @@ from Utils.response_version import ResponseVersion
 
 class StampRequestV4:
     @staticmethod
-    def stamp(url: str, token: str, xml: str, headers: dict, version: ResponseVersion):
-        """
-        Método estático para timbrar usando el servicio Timbrado v4 con soporte de versiones de respuesta.
-        """
-        path = f"/v4/cfdi33/stamp/{str(version)}"
+    def _build_headers(headers: dict, email, custom_id: str, pdf: bool) -> dict:
+        request_headers = {}
+        if email:
+            request_headers['email'] = ",".join(email) if isinstance(email, list) else email
+        if custom_id:
+            request_headers['customid'] = custom_id
+        if pdf:
+            request_headers['extra'] = "pdf"
+        if headers:
+            request_headers.update(headers)
+        return request_headers
+
+    @staticmethod
+    def stamp(url: str, token: str, xml: str, headers: dict, version: ResponseVersion,
+              email=None, custom_id: str = None, pdf: bool = False, b64: bool = False):
+        bs64 = "/b64" if b64 else ""
+        path = f"/v4/cfdi33/stamp/{str(version)}{bs64}"
         complete_url = f"{url}{path}"
         response = RequestHelper.post_v4(
             endpoint=complete_url,
             content=xml,
             token=token,
-            headers=headers
+            headers=StampRequestV4._build_headers(headers, email, custom_id, pdf)
         )
         return StampResponse(response)

--- a/Stamp/StampV4.py
+++ b/Stamp/StampV4.py
@@ -6,11 +6,16 @@ class StampV4(Services):
     def __init__(self, url, token=None, user=None, password=None):
         super(StampV4, self).__init__(url, token, user, password)
 
-    def stamp(self, xml: str, headers: dict = None, version: ResponseVersion = ResponseVersion.V1):
+    def stamp(self, xml: str, headers: dict = None, version: ResponseVersion = ResponseVersion.V1,
+              email=None, custom_id: str = None, pdf: bool = False, b64: bool = False):
         return StampRequestV4.stamp(
             url=self.get_url(),
             token=self.get_token(),
             xml=xml,
             headers=headers,
-            version=version
+            version=version,
+            email=email,
+            custom_id=custom_id,
+            pdf=pdf,
+            b64=b64
         )

--- a/Test/test_v4_services.py
+++ b/Test/test_v4_services.py
@@ -64,7 +64,7 @@ class TestV4Basic(unittest.TestCase):
         data["Fecha"] = new_date
         return json.dumps(data, indent=2, ensure_ascii=False)
 
-    def esperar_url_pdf(self, uuid):
+    def wait_url_pdf(self, uuid):
         #El PDF del comprobante tarda en quedar disponible en el ADT.
         storage = Storage(self.url, self.urlApi, self.token)
         for _ in range(12):
@@ -90,7 +90,7 @@ class TestV4Basic(unittest.TestCase):
         self.assertIsNotNone(response.data)
         self.assertIsNotNone(response.data.get("cfdi"))
         self.assertIsNotNone(response.data.get("uuid"))
-        self.assertIsNotNone(self.esperar_url_pdf(response.data.get("uuid")),
+        self.assertIsNotNone(self.wait_url_pdf(response.data.get("uuid")),
                              "El comprobante se timbró sin generar el PDF en el ADT")
 
     def test_issue_xml_token_minimal_headers(self):
@@ -106,7 +106,6 @@ class TestV4Basic(unittest.TestCase):
         self.assertIsNotNone(response.data.get("cfdi"))
 
     def test_issue_xml_headers_dict(self):
-        #El diccionario headers se conserva y sus valores prevalecen sobre los parámetros.
         issue = IssueV4(self.url, self.token)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
         headers = {
@@ -144,7 +143,6 @@ class TestV4Basic(unittest.TestCase):
                                pdf=True,
                                version=ResponseVersion.V2)
 
-        #El comprobante de pruebas ya está timbrado: el servicio responde con el timbre previo.
         if response.get_status() == "error":
             self.assertIn("307", response.get_message())
         else:
@@ -224,7 +222,7 @@ class TestV4Basic(unittest.TestCase):
         self.assertEqual(200, response.status_code)
         self.assertIsNotNone(response.data)
         self.assertIsNotNone(response.data.get("uuid"))
-        self.assertIsNotNone(self.esperar_url_pdf(response.data.get("uuid")),
+        self.assertIsNotNone(self.wait_url_pdf(response.data.get("uuid")),
                              "El comprobante se timbró sin generar el PDF en el ADT")
 
     #UT de Error

--- a/Test/test_v4_services.py
+++ b/Test/test_v4_services.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import sys
 import json
+from base64 import b64encode
 from datetime import datetime, timedelta
 import xml.etree.ElementTree as ET
 from io import BytesIO
@@ -9,350 +10,297 @@ from pathlib import Path
 import random
 import string
 import time
-from typing import Union
 
 PROJECT_ROOT = str(Path(__file__).parent.parent.absolute())
 sys.path.insert(0, PROJECT_ROOT)
 
 from Issue.IssueV4 import IssueV4
 from Stamp.StampV4 import StampV4
+from Storage.Storage import Storage
 from Utils.response_version import ResponseVersion
 
 class TestV4Basic(unittest.TestCase):
-    """
-    Pruebas básicas para los servicios V4 de CFDI.
-    Se prueban escenarios de éxito y error para Issue y Stamp.
-    """
-    
+
     def setUp(self):
-        """Configuración inicial para todas las pruebas"""
-        self.url = "http://services.test.sw.com.mx"
+        self.url = "https://services.test.sw.com.mx"
+        self.urlApi = "https://api.test.sw.com.mx"
         self.user = os.environ.get("SDKTEST_USER")
         self.password = os.environ.get("SDKTEST_PASSWORD")
         self.token = os.environ.get("SDKTEST_TOKEN")
-        
+
         if not all([self.user, self.password, self.token]):
             raise ValueError("Faltan variables de entorno necesarias: SDKTEST_USER, SDKTEST_PASSWORD, SDKTEST_TOKEN")
-    
+
     @staticmethod
     def generate_custom_id(prefix):
-        """Genera un customId único usando un prefijo y caracteres aleatorios"""
-        # Genera 4 caracteres aleatorios (2 letras y 2 números)
         letters = ''.join(random.choices(string.ascii_uppercase, k=2))
         numbers = ''.join(random.choices(string.digits, k=2))
         timestamp = datetime.now().strftime("%H%M")
         return f"{prefix}-{letters}{numbers}-{timestamp}"
-    
+
     @staticmethod
     def update_date_xml(path_xml):
-        """Actualiza la fecha en un archivo XML a la hora actual menos 1 hora"""
-        try:
-            ns = {"cfdi": "http://www.sat.gob.mx/cfd/4"}
-            tree = ET.parse(path_xml)
-            root = tree.getroot()
-            
-            new_date = datetime.now() - timedelta(hours=1)
-            if "Fecha" in root.attrib:
-                root.set("Fecha", new_date.strftime("%Y-%m-%dT%H:%M:%S"))
-                ET.register_namespace("cfdi", ns["cfdi"]) 
-                xml_buffer = BytesIO()
-                tree.write(xml_buffer, encoding="utf-8", xml_declaration=True)
-                return xml_buffer.getvalue().decode("utf-8")
-            else:
-                raise ValueError("No se encontró el atributo 'Fecha' en el XML")
-        except Exception as e:
-            raise
+        ns = {"cfdi": "http://www.sat.gob.mx/cfd/4"}
+        tree = ET.parse(path_xml)
+        root = tree.getroot()
 
-    # ============= CASOS DE ÉXITO =============
-
-    def test_issue_xml_auth_all_headers(self):
-        """Escenario 1: Issue XML exitoso con autenticación por credenciales y todos los headers"""
-        try:
-            issue = IssueV4(self.url, None, self.user, self.password)
-            xml_content = self.update_date_xml("Test/resources/xml40.xml")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISS"),
-                "email": "test1@test.com,test2@test.com",
-                "pdf": "true"
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("success", response.get_status())
-            self.assertIsNotNone(response.data)
-            self.assertIsNotNone(response.data.get("cfdi")) #Dato de version 4
-            self.assertIsNotNone(response.data.get("uuid")) #Dato de version 4 - UUID del comprobante
-            self.assertEqual(200, response.status_code)
-        except Exception as e:
-            raise
-
-    def test_issue_xml_token_minimal_headers(self):
-        """Escenario 2: Issue XML exitoso con token y solo customId"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            xml_content = self.update_date_xml("Test/resources/xml40.xml")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISS")
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V3)
-            
-            self.assertEqual("success", response.get_status())
-            self.assertEqual(200, response.status_code)
-            self.assertIsNotNone(response.data.get("cfdi")) #Dato de version 3
-        except Exception as e:
-            raise
-
-    def test_stamp_token_all_headers(self):
-        """Escenario 3: Stamp exitoso con token y todos los headers"""
-        try:
-            stamp = StampV4(self.url, self.token)
-            xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
-            
-            headers = {
-                "customid": self.generate_custom_id("STP"),
-                "email": "stamp1@test.com,stamp2@test.com",
-                "pdf": "true"
-            }
-            
-            response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
-            
-            if response.get_status() == "error":
-                self.assertIn("307", response.get_message())
-                self.assertIn("timbre previo", response.get_message().lower())
-            else:
-                self.assertEqual("success", response.get_status())
-                self.assertEqual(200, response.status_code)
-                self.assertIsNotNone(response.data.get("tfd")) #Dato de version 2
-        except Exception as e:
-            raise
-
-    def test_stamp_auth_email_only(self):
-        """Escenario 4: Stamp exitoso con credenciales y solo email"""
-        try:
-            stamp = StampV4(self.url, None, self.user, self.password)
-            xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
-            
-            headers = {
-                "email": "stamp1@test.com"
-            }
-            
-            response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            if response.get_status() == "error":
-                self.assertIn("307", response.get_message())
-                self.assertIn("timbre previo", response.get_message().lower())
-            else:
-                self.assertEqual("success", response.get_status())
-                self.assertEqual(200, response.status_code)
-        except Exception as e:
-            raise
-
-    def test_issue_json_auth_all_headers(self):
-        """Escenario 5: Issue JSON exitoso con autenticación y todos los headers"""
-        try:
-            issue = IssueV4(self.url, None, self.user, self.password)
-            json_content = self.update_date_json("Test/resources/cfdi.json")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISJ"),
-                "email": "test1@test.com,test2@test.com",
-                "pdf": "true"
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("success", response.get_status())
-            self.assertIsNotNone(response.data)
-            self.assertIsNotNone(response.data.get("cfdi")) #Dato de version 4
-            self.assertIsNotNone(response.data.get("uuid")) #Dato de version 4 - UUID del comprobante
-            self.assertEqual(200, response.status_code)
-        except Exception as e:
-            raise
-
-    def test_issue_json_token_minimal_headers(self):
-        """Escenario 6: Issue JSON exitoso con token y solo customId usando V3"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            time.sleep(5)
-            json_content = self.update_date_json("Test/resources/cfdi.json")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISJ")
-            }
-           
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V3)
-            
-            self.assertEqual("success", response.get_status())
-            self.assertEqual(200, response.status_code)
-            self.assertIsNotNone(response.data.get("cfdi")) #Dato de version 3
-        except Exception as e:
-            raise
-
-    def test_issue_json_with_pdf(self):
-        """Escenario 7: Issue JSON exitoso validando respuesta con PDF"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            time.sleep(5)
-            json_content = self.update_date_json("Test/resources/cfdi.json")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISJ"),
-                "pdf": "true",
-                "email": "test1@test.com"
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("success", response.get_status())
-            self.assertEqual(200, response.status_code)
-            self.assertIsNotNone(response.data)
-            self.assertIsNotNone(response.data.get("cfdi")) #Dato de version 4
-            self.assertIsNotNone(response.data.get("uuid")) #Dato de version 4 - UUID del comprobante
-        except Exception as e:
-            raise
-
-    # ============= CASOS DE ERROR =============
-
-    def test_issue_xml_invalid_credentials(self):
-        """Error 1: Issue XML con credenciales inválidas"""
-        try:
-            issue = IssueV4(self.url, None, "usuario_invalido", "pass_invalido")
-            xml_content = self.update_date_xml("Test/resources/xml40.xml")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISS")
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response.get_status())
-            self.assertNotEqual(200, response.status_code)
-            self.assertIsNone(response.data)
-            self.assertEqual("AU4101 - El token proporcionado viene vacio.", response.get_message())
-        except Exception as e:
-            raise
-
-    def test_issue_xml_invalid_xml(self):
-        """Error 2: Issue XML con XML mal formado o sin certificado"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            xml_content = "<xml>mal formado</xml>"
-            
-            headers = {
-                "customid": self.generate_custom_id("ISS")
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response.get_status())
-            self.assertNotEqual(200, response.status_code)
-            self.assertIsNotNone(response.get_message)
-        except Exception as e:
-            raise
-
-    def test_stamp_invalid_token(self):
-        """Error 3: Stamp con token inválido"""
-        try:
-            stamp = StampV4(self.url, "token_invalido")
-            xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
-            
-            headers = {
-                "customid": self.generate_custom_id("STP")
-            }
-            
-            response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response.get_status())
-            self.assertEqual("El token debe contener 3 partes", response.get_message())
-            self.assertNotEqual(200, response.status_code)
-        except Exception as e:
-            raise
-
-    def test_stamp_invalid_email_format(self):
-        """Error 4: Stamp con formato de email inválido"""
-        try:
-            stamp = StampV4(self.url, self.token)
-            xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
-            
-            headers = {
-                "customid": self.generate_custom_id("STP"),
-                "email": "correo_invalido"
-            }
-            
-            response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response.get_status())
-            self.assertNotEqual(200, response.status_code)
-            self.assertEqual("El header email no tiene un correo válido (email).", response.get_message())
-        except Exception as e:
-            raise
-
-    def test_issue_duplicate_custom_id(self):
-        """Error 5: Issue - Error al intentar usar un customId duplicado"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            xml_content = self.update_date_xml("Test/resources/xml40.xml")
-            
-            custom_id = self.generate_custom_id("ISS")
-            headers = {
-                "customid": custom_id
-            }
-            
-            response1 = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("success", response1.get_status())
-            self.assertIsNotNone(response1.data.get("cfdi")) #Dato de version 4
-            self.assertIsNotNone(response1.data.get("uuid")) #Dato de version 4 - UUID del comprobante
-            self.assertEqual(200, response1.status_code)
-            
-            response2 = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response2.get_status())
-            self.assertEqual("307. El comprobante contiene un timbre previo.", response2.get_message())
-        except Exception as e:
-            raise
-
-    def test_issue_json_invalid_format(self):
-        """Error 6: Issue JSON con formato inválido"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            json_content = '{"invalid": "json format for cfdi"}'
-            
-            headers = {
-                "customid": self.generate_custom_id("ISJ")
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response.get_status())
-            self.assertNotEqual(200, response.status_code)
-            self.assertIsNotNone(response.get_message())
-        except Exception as e:
-            raise
+        new_date = datetime.now() - timedelta(hours=1)
+        if "Fecha" not in root.attrib:
+            raise ValueError("No se encontró el atributo 'Fecha' en el XML")
+        root.set("Fecha", new_date.strftime("%Y-%m-%dT%H:%M:%S"))
+        ET.register_namespace("cfdi", ns["cfdi"])
+        xml_buffer = BytesIO()
+        tree.write(xml_buffer, encoding="utf-8", xml_declaration=True)
+        return xml_buffer.getvalue().decode("utf-8")
 
     @staticmethod
     def update_date_json(path_json):
-        """Actualiza la fecha en un archivo JSON a la hora actual menos 1 hora"""
-        try:
-            with open(path_json, "r", encoding="utf-8") as file:
-                data = json.load(file)
-            
-            new_date = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
-            if "Fecha" in data:
-                data["Fecha"] = new_date
-                return json.dumps(data, indent=2, ensure_ascii=False)
-            else:
-                raise ValueError("No se encontró la clave 'Fecha' en el JSON")
-        except Exception as e:
-            raise
+        with open(path_json, "r", encoding="utf-8") as file:
+            data = json.load(file)
+
+        new_date = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+        if "Fecha" not in data:
+            raise ValueError("No se encontró la clave 'Fecha' en el JSON")
+        data["Fecha"] = new_date
+        return json.dumps(data, indent=2, ensure_ascii=False)
+
+    def esperar_url_pdf(self, uuid):
+        #El PDF del comprobante tarda en quedar disponible en el ADT.
+        storage = Storage(self.url, self.urlApi, self.token)
+        for _ in range(12):
+            time.sleep(10)
+            url_pdf = storage.get_by_uuid(uuid).get_url_pdf()
+            if url_pdf:
+                return url_pdf
+        return None
+
+    #UT Emisión de Timbrado XML
+    def test_issue_xml_auth_all_headers(self):
+        issue = IssueV4(self.url, None, self.user, self.password)
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+
+        response = issue.issue_xml(xml_content,
+                                   custom_id=self.generate_custom_id("ISS"),
+                                   email=["test1@test.com", "test2@test.com"],
+                                   pdf=True,
+                                   version=ResponseVersion.V4)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data)
+        self.assertIsNotNone(response.data.get("cfdi"))
+        self.assertIsNotNone(response.data.get("uuid"))
+        self.assertIsNotNone(self.esperar_url_pdf(response.data.get("uuid")),
+                             "El comprobante se timbró sin generar el PDF en el ADT")
+
+    def test_issue_xml_token_minimal_headers(self):
+        issue = IssueV4(self.url, self.token)
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+
+        response = issue.issue_xml(xml_content,
+                                   custom_id=self.generate_custom_id("ISS"),
+                                   version=ResponseVersion.V3)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data.get("cfdi"))
+
+    def test_issue_xml_headers_dict(self):
+        #El diccionario headers se conserva y sus valores prevalecen sobre los parámetros.
+        issue = IssueV4(self.url, self.token)
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data.get("uuid"))
+
+    def test_issue_xml_b64(self):
+        issue = IssueV4(self.url, self.token)
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+        xml_b64 = b64encode(xml_content.encode("utf-8")).decode()
+
+        response = issue.issue_xml(xml_b64,
+                                   custom_id=self.generate_custom_id("ISS"),
+                                   version=ResponseVersion.V4,
+                                   b64=True)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data.get("uuid"))
+
+    #UT Timbrado XML
+    def test_stamp_token_all_headers(self):
+        stamp = StampV4(self.url, self.token)
+        xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
+
+        response = stamp.stamp(xml_content,
+                               custom_id=self.generate_custom_id("STP"),
+                               email="stamp1@test.com,stamp2@test.com",
+                               pdf=True,
+                               version=ResponseVersion.V2)
+
+        #El comprobante de pruebas ya está timbrado: el servicio responde con el timbre previo.
+        if response.get_status() == "error":
+            self.assertIn("307", response.get_message())
+        else:
+            self.assertEqual("success", response.get_status())
+            self.assertEqual(200, response.status_code)
+            self.assertIsNotNone(response.data.get("tfd"))
+
+    def test_stamp_auth_email_only(self):
+        stamp = StampV4(self.url, None, self.user, self.password)
+        xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
+
+        response = stamp.stamp(xml_content, email="stamp1@test.com", version=ResponseVersion.V4)
+
+        if response.get_status() == "error":
+            self.assertIn("307", response.get_message())
+        else:
+            self.assertEqual("success", response.get_status())
+            self.assertEqual(200, response.status_code)
+
+    def test_stamp_b64(self):
+        stamp = StampV4(self.url, self.token)
+        xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
+        xml_b64 = b64encode(xml_content.encode("utf-8")).decode()
+
+        response = stamp.stamp(xml_b64,
+                               custom_id=self.generate_custom_id("STP"),
+                               version=ResponseVersion.V2,
+                               b64=True)
+
+        if response.get_status() == "error":
+            self.assertIn("307", response.get_message())
+        else:
+            self.assertEqual("success", response.get_status())
+            self.assertEqual(200, response.status_code)
+
+    #UT Emisión de Timbrado JSON
+    def test_issue_json_auth_all_headers(self):
+        issue = IssueV4(self.url, None, self.user, self.password)
+        json_content = self.update_date_json("Test/resources/cfdi.json")
+
+        response = issue.issue_json(json_content,
+                                    custom_id=self.generate_custom_id("ISJ"),
+                                    email=["test1@test.com", "test2@test.com"],
+                                    version=ResponseVersion.V4)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data)
+        self.assertIsNotNone(response.data.get("cfdi"))
+        self.assertIsNotNone(response.data.get("uuid"))
+
+    def test_issue_json_token_minimal_headers(self):
+        issue = IssueV4(self.url, self.token)
+        time.sleep(5)
+        json_content = self.update_date_json("Test/resources/cfdi.json")
+
+        response = issue.issue_json(json_content,
+                                    custom_id=self.generate_custom_id("ISJ"),
+                                    version=ResponseVersion.V3)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data.get("cfdi"))
+
+    def test_issue_json_with_pdf(self):
+        issue = IssueV4(self.url, self.token)
+        time.sleep(5)
+        json_content = self.update_date_json("Test/resources/cfdi.json")
+
+        response = issue.issue_json(json_content,
+                                    custom_id=self.generate_custom_id("ISJ"),
+                                    email="test1@test.com",
+                                    pdf=True,
+                                    version=ResponseVersion.V4)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data)
+        self.assertIsNotNone(response.data.get("uuid"))
+        self.assertIsNotNone(self.esperar_url_pdf(response.data.get("uuid")),
+                             "El comprobante se timbró sin generar el PDF en el ADT")
+
+    #UT de Error
+    def test_issue_xml_invalid_credentials(self):
+        issue = IssueV4(self.url, None, "usuario_invalido", "pass_invalido")
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+
+        response = issue.issue_xml(xml_content, custom_id=self.generate_custom_id("ISS"), version=ResponseVersion.V4)
+
+        self.assertEqual("error", response.get_status())
+        self.assertNotEqual(200, response.status_code)
+        self.assertIsNone(response.data)
+        self.assertIn("AU4101", response.get_message())
+
+    def test_issue_xml_invalid_xml(self):
+        issue = IssueV4(self.url, self.token)
+
+        response = issue.issue_xml("<xml>mal formado</xml>",
+                                   custom_id=self.generate_custom_id("ISS"),
+                                   version=ResponseVersion.V4)
+
+        self.assertEqual("error", response.get_status())
+        self.assertNotEqual(200, response.status_code)
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+
+    def test_stamp_invalid_token(self):
+        stamp = StampV4(self.url, "token_invalido")
+        xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
+
+        response = stamp.stamp(xml_content, custom_id=self.generate_custom_id("STP"), version=ResponseVersion.V4)
+
+        self.assertEqual("error", response.get_status())
+        self.assertNotEqual(200, response.status_code)
+        self.assertIn("token", response.get_message().lower())
+
+    def test_stamp_invalid_email_format(self):
+        stamp = StampV4(self.url, self.token)
+        xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
+
+        response = stamp.stamp(xml_content,
+                               custom_id=self.generate_custom_id("STP"),
+                               email="correo_invalido",
+                               version=ResponseVersion.V4)
+
+        self.assertEqual("error", response.get_status())
+        self.assertNotEqual(200, response.status_code)
+        self.assertIn("email", response.get_message().lower())
+
+    def test_issue_duplicate_custom_id(self):
+        issue = IssueV4(self.url, self.token)
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+        custom_id = self.generate_custom_id("ISS")
+
+        response1 = issue.issue_xml(xml_content, custom_id=custom_id, version=ResponseVersion.V4)
+
+        self.assertEqual("success", response1.get_status())
+        self.assertEqual(200, response1.status_code)
+        self.assertIsNotNone(response1.data.get("uuid"))
+
+        response2 = issue.issue_xml(xml_content, custom_id=custom_id, version=ResponseVersion.V4)
+
+        self.assertEqual("error", response2.get_status())
+        self.assertIn("307", response2.get_message())
+
+    def test_issue_json_invalid_format(self):
+        issue = IssueV4(self.url, self.token)
+
+        response = issue.issue_json('{"invalid": "json format for cfdi"}',
+                                    custom_id=self.generate_custom_id("ISJ"),
+                                    version=ResponseVersion.V4)
+
+        self.assertEqual("error", response.get_status())
+        self.assertNotEqual(200, response.status_code)
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
 
 if __name__ == '__main__':
-    try:
-        suite = unittest.TestLoader().loadTestsFromTestCase(TestV4Basic)
-        result = unittest.TextTestRunner(verbosity=2).run(suite)
-        sys.exit(not result.wasSuccessful())
-    except Exception as e:
-        sys.exit(1) 
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestV4Basic)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/Test/test_v4_services.py
+++ b/Test/test_v4_services.py
@@ -75,7 +75,7 @@ class TestV4Basic(unittest.TestCase):
         return None
 
     #UT Emisión de Timbrado XML
-    def test_issue_xml_auth_all_headers(self):
+    def test_issue_xml_auth_named_params(self):
         issue = IssueV4(self.url, None, self.user, self.password)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
 
@@ -97,36 +97,47 @@ class TestV4Basic(unittest.TestCase):
         issue = IssueV4(self.url, self.token)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
 
-        response = issue.issue_xml(xml_content,
-                                   custom_id=self.generate_custom_id("ISS"),
-                                   version=ResponseVersion.V3)
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V3)
 
         self.assertEqual("success", response.get_status())
         self.assertEqual(200, response.status_code)
         self.assertIsNotNone(response.data.get("cfdi"))
 
-    def test_issue_xml_headers_dict(self):
+    def test_issue_xml_headers_over_named_params(self):
         issue = IssueV4(self.url, self.token)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
+
         headers = {
             "customid": self.generate_custom_id("ISS")
         }
 
-        response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
+        response1 = issue.issue_xml(xml_content, headers=headers,
+                                    custom_id=self.generate_custom_id("OTR"),
+                                    version=ResponseVersion.V4)
 
-        self.assertEqual("success", response.get_status())
-        self.assertEqual(200, response.status_code)
-        self.assertIsNotNone(response.data.get("uuid"))
+        self.assertEqual("success", response1.get_status())
+        self.assertEqual(200, response1.status_code)
+
+        #El customid que llegó al servicio es el del diccionario: al repetirlo responde con el timbre previo.
+        response2 = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
+
+        self.assertEqual("error", response2.get_status())
+        self.assertIn("307", response2.get_message())
 
     def test_issue_xml_b64(self):
         issue = IssueV4(self.url, self.token)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
         xml_b64 = b64encode(xml_content.encode("utf-8")).decode()
 
-        response = issue.issue_xml(xml_b64,
-                                   custom_id=self.generate_custom_id("ISS"),
-                                   version=ResponseVersion.V4,
-                                   b64=True)
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response = issue.issue_xml(xml_b64, headers=headers, version=ResponseVersion.V4, b64=True)
 
         self.assertEqual("success", response.get_status())
         self.assertEqual(200, response.status_code)
@@ -137,11 +148,13 @@ class TestV4Basic(unittest.TestCase):
         stamp = StampV4(self.url, self.token)
         xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
 
-        response = stamp.stamp(xml_content,
-                               custom_id=self.generate_custom_id("STP"),
-                               email="stamp1@test.com,stamp2@test.com",
-                               pdf=True,
-                               version=ResponseVersion.V2)
+        headers = {
+            "customid": self.generate_custom_id("STP"),
+            "email": "stamp1@test.com,stamp2@test.com",
+            "extra": "pdf"
+        }
+
+        response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
 
         if response.get_status() == "error":
             self.assertIn("307", response.get_message())
@@ -154,7 +167,11 @@ class TestV4Basic(unittest.TestCase):
         stamp = StampV4(self.url, None, self.user, self.password)
         xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
 
-        response = stamp.stamp(xml_content, email="stamp1@test.com", version=ResponseVersion.V4)
+        headers = {
+            "email": "stamp1@test.com"
+        }
+
+        response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
 
         if response.get_status() == "error":
             self.assertIn("307", response.get_message())
@@ -167,10 +184,11 @@ class TestV4Basic(unittest.TestCase):
         xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
         xml_b64 = b64encode(xml_content.encode("utf-8")).decode()
 
-        response = stamp.stamp(xml_b64,
-                               custom_id=self.generate_custom_id("STP"),
-                               version=ResponseVersion.V2,
-                               b64=True)
+        headers = {
+            "customid": self.generate_custom_id("STP")
+        }
+
+        response = stamp.stamp(xml_b64, headers=headers, version=ResponseVersion.V2, b64=True)
 
         if response.get_status() == "error":
             self.assertIn("307", response.get_message())
@@ -183,10 +201,12 @@ class TestV4Basic(unittest.TestCase):
         issue = IssueV4(self.url, None, self.user, self.password)
         json_content = self.update_date_json("Test/resources/cfdi.json")
 
-        response = issue.issue_json(json_content,
-                                    custom_id=self.generate_custom_id("ISJ"),
-                                    email=["test1@test.com", "test2@test.com"],
-                                    version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISJ"),
+            "email": "test1@test.com,test2@test.com"
+        }
+
+        response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("success", response.get_status())
         self.assertEqual(200, response.status_code)
@@ -199,9 +219,11 @@ class TestV4Basic(unittest.TestCase):
         time.sleep(5)
         json_content = self.update_date_json("Test/resources/cfdi.json")
 
-        response = issue.issue_json(json_content,
-                                    custom_id=self.generate_custom_id("ISJ"),
-                                    version=ResponseVersion.V3)
+        headers = {
+            "customid": self.generate_custom_id("ISJ")
+        }
+
+        response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V3)
 
         self.assertEqual("success", response.get_status())
         self.assertEqual(200, response.status_code)
@@ -212,11 +234,13 @@ class TestV4Basic(unittest.TestCase):
         time.sleep(5)
         json_content = self.update_date_json("Test/resources/cfdi.json")
 
-        response = issue.issue_json(json_content,
-                                    custom_id=self.generate_custom_id("ISJ"),
-                                    email="test1@test.com",
-                                    pdf=True,
-                                    version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISJ"),
+            "email": "test1@test.com",
+            "extra": "pdf"
+        }
+
+        response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("success", response.get_status())
         self.assertEqual(200, response.status_code)
@@ -230,7 +254,11 @@ class TestV4Basic(unittest.TestCase):
         issue = IssueV4(self.url, None, "usuario_invalido", "pass_invalido")
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
 
-        response = issue.issue_xml(xml_content, custom_id=self.generate_custom_id("ISS"), version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response.get_status())
         self.assertNotEqual(200, response.status_code)
@@ -240,9 +268,11 @@ class TestV4Basic(unittest.TestCase):
     def test_issue_xml_invalid_xml(self):
         issue = IssueV4(self.url, self.token)
 
-        response = issue.issue_xml("<xml>mal formado</xml>",
-                                   custom_id=self.generate_custom_id("ISS"),
-                                   version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response = issue.issue_xml("<xml>mal formado</xml>", headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response.get_status())
         self.assertNotEqual(200, response.status_code)
@@ -252,7 +282,11 @@ class TestV4Basic(unittest.TestCase):
         stamp = StampV4(self.url, "token_invalido")
         xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
 
-        response = stamp.stamp(xml_content, custom_id=self.generate_custom_id("STP"), version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("STP")
+        }
+
+        response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response.get_status())
         self.assertNotEqual(200, response.status_code)
@@ -262,10 +296,12 @@ class TestV4Basic(unittest.TestCase):
         stamp = StampV4(self.url, self.token)
         xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
 
-        response = stamp.stamp(xml_content,
-                               custom_id=self.generate_custom_id("STP"),
-                               email="correo_invalido",
-                               version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("STP"),
+            "email": "correo_invalido"
+        }
+
+        response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response.get_status())
         self.assertNotEqual(200, response.status_code)
@@ -274,15 +310,18 @@ class TestV4Basic(unittest.TestCase):
     def test_issue_duplicate_custom_id(self):
         issue = IssueV4(self.url, self.token)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
-        custom_id = self.generate_custom_id("ISS")
 
-        response1 = issue.issue_xml(xml_content, custom_id=custom_id, version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response1 = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("success", response1.get_status())
         self.assertEqual(200, response1.status_code)
         self.assertIsNotNone(response1.data.get("uuid"))
 
-        response2 = issue.issue_xml(xml_content, custom_id=custom_id, version=ResponseVersion.V4)
+        response2 = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response2.get_status())
         self.assertIn("307", response2.get_message())
@@ -290,9 +329,11 @@ class TestV4Basic(unittest.TestCase):
     def test_issue_json_invalid_format(self):
         issue = IssueV4(self.url, self.token)
 
-        response = issue.issue_json('{"invalid": "json format for cfdi"}',
-                                    custom_id=self.generate_custom_id("ISJ"),
-                                    version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISJ")
+        }
+
+        response = issue.issue_json('{"invalid": "json format for cfdi"}', headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response.get_status())
         self.assertNotEqual(200, response.status_code)

--- a/Utils/requestHelper.py
+++ b/Utils/requestHelper.py
@@ -95,23 +95,25 @@ class RequestHelper:
     @staticmethod
     def post_v4_json(endpoint: str, content: Union[str, dict], token: str = None, headers: Dict = None) -> requests.Response:
         request_headers = {
-            'Authorization': f'Bearer {token}' if token else None,
+            'Authorization': f'bearer {token}' if token else None,
             'Content-Type': 'application/jsontoxml; charset=utf-8'
         }
         if headers:
             request_headers.update(headers)
         if isinstance(content, dict):
             content = json.dumps(content, ensure_ascii=False)
-        return requests.post(endpoint, data=content.encode('utf-8'), headers=request_headers)
+        session = RequestHelper._get_session()
+        return session.post(endpoint, data=content.encode('utf-8'), headers=request_headers, verify=True, timeout=300)
 
     @staticmethod
     def post_v4(endpoint: str, content: Union[str, dict], token: str = None, headers: Dict = None) -> requests.Response:
         request_headers = {
-            'Authorization': f'Bearer {token}' if token else None
+            'Authorization': f'bearer {token}' if token else None
         }
         if headers:
             request_headers.update(headers)
         boundary = ''.join(random.choices(string.ascii_letters + string.digits, k=30))
         request_headers['Content-Type'] = f'multipart/form-data; boundary={boundary}'
         body = RequestHelper._create_multipart_body(content, boundary)
-        return requests.post(endpoint, data=body, headers=request_headers)
+        session = RequestHelper._get_session()
+        return session.post(endpoint, data=body, headers=request_headers, verify=True, timeout=300)

--- a/Utils/response_version.py
+++ b/Utils/response_version.py
@@ -1,11 +1,10 @@
 from enum import Enum
 
 class ResponseVersion(Enum):
-    """Enum for CFDI response versions"""
     V1 = "v1"
     V2 = "v2"
     V3 = "v3"
     V4 = "v4"
-    
+
     def __str__(self):
-        return self.value 
+        return self.value

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 setuptools.setup(
     name='sw-sdk-python',
-    version='0.0.11.1',
+    version='0.0.12.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
### Actividad

SS-274 – Actualización librerías – Revisión Timbrado V4 – Python

### Qué incluye

**Correcciones**

- Se corrige el header de confirmación de PDF: el servicio lo recibe como `extra: pdf` y la librería documentaba y probaba `pdf: true`, que se ignora en silencio. Verificado contra el ambiente de pruebas: con `extra: pdf` el PDF queda en el ADT, con `pdf: true` no se genera.
- `post_v4` y `post_v4_json` eran los dos únicos helpers que hacían la petición directa: ahora usan sesión, `timeout` y `verify`, igual que el resto de `Utils/requestHelper.py`, y el esquema de autorización queda en minúscula como en toda la librería.
- Se corrige el decorador mal colocado en `IssueRequestV4`.

**Uniformidad con el resto del repositorio**

- Se retiran los docstrings de los servicios V4 y del enum `ResponseVersion`, para que el módulo se lea como `Csd/`, `Pdf/`, `Storage/` y los demás, que no los usan.
- Las URLs de prueba del README pasan a `https://`, como en las secciones actualizadas en el resto de la actividad.
- Las UT adoptan el patrón de la suite: agrupadas con comentarios `#UT ...`, sin docstrings por escenario y sin el `try/except` que sólo relanzaba la excepción.

**Mejoras**

- Parámetros opcionales `email`, `custom_id` y `pdf` en `StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`, para no tener que adivinar el nombre de los headers, que es el origen del error corregido. `email` acepta cadena o lista. El diccionario `headers` se sigue recibiendo y sus valores prevalecen sobre los parámetros.
- Soporte del formato `b64` en `stamp` e `issue_xml`, con el mismo nombre y semántica que en los métodos V1 a V3, donde ya existía. No aplica en `issue_json`.
- Las UT dejan de afirmar cadenas exactas de los mensajes del servicio, que se rompen en cuanto cambia el texto, y afirman `status`, `status_code` y un fragmento estable. Se agregan escenarios de `b64` y del diccionario `headers`, y los escenarios de PDF comprueban que el archivo exista en el ADT en lugar de dar por bueno el `status`.
- Se documentan en el README los parámetros nuevos y el enum `ResponseVersion` con el enlace a las versiones de respuesta, y se arregla la indentación de los nueve bloques de ejemplo, que no eran copiables ni ejecutables tal cual.

Por el cambio en `Utils/requestHelper.py`, que es archivo compartido, se corrió la suite completa del repositorio: `test_v4_services.py` queda en 16/16 y los demás archivos dan el mismo resultado que en `develop`.

### Versión

`0.0.11.1` → `0.0.12.1` (feature: se agrega funcionalidad)

### Criterios de aceptación

- [x] CustomId, Email y confirmación de PDF con el header correcto y por parámetro nombrado
- [x] Soporte del formato `b64` en Timbrado y Emisión V4
- [x] UTs en success
- [x] Documentación corregida en el README