### PR TITLE
Release/0.0.12.1

### DIFF
--- a/Csd/Csd.py
+++ b/Csd/Csd.py
@@ -23,3 +23,11 @@ class Csd(Services):
     def disable_csd(self, certificate_number):
         """Desactiva un certificado por su número de certificado (equivalente a DisableMyCsd en .NET)."""
         return CsdRequest.disable_csd(self.get_url(), self.get_token(), certificate_number)
+
+    def get_list_csd_by_type(self, certificate_type):
+        """Consulta los certificados de un tipo (equivalente a GetListCsdByType en .NET)."""
+        return CsdRequest.get_list_csd_by_type(self.get_url(), self.get_token(), certificate_type)
+
+    def get_active_csd(self, rfc, certificate_type):
+        """Consulta el certificado activo de un RFC por tipo (equivalente a SearchActiveCsd en .NET)."""
+        return CsdRequest.get_active_csd(self.get_url(), self.get_token(), rfc, certificate_type)

--- a/Csd/Csd.py
+++ b/Csd/Csd.py
@@ -9,25 +9,19 @@ class Csd(Services):
         return CsdRequest.upload_csd(self.get_url(), self.get_token(), certificate_type, b64_cert, b64_key, password)
 
     def get_list_csd(self):
-        """Consulta todos los certificados de la cuenta (equivalente a GetListCsd en .NET)."""
         return CsdRequest.get_list_csd(self.get_url(), self.get_token())
 
     def get_csd(self, certificate_number):
-        """Consulta un certificado por su número de certificado (equivalente a SearchMyCsd en .NET)."""
         return CsdRequest.get_csd(self.get_url(), self.get_token(), certificate_number)
 
     def get_list_csd_by_rfc(self, rfc):
-        """Consulta los certificados de un RFC (equivalente a GetListCsdByRfc en .NET)."""
         return CsdRequest.get_list_csd_by_rfc(self.get_url(), self.get_token(), rfc)
 
     def disable_csd(self, certificate_number):
-        """Desactiva un certificado por su número de certificado (equivalente a DisableMyCsd en .NET)."""
         return CsdRequest.disable_csd(self.get_url(), self.get_token(), certificate_number)
 
     def get_list_csd_by_type(self, certificate_type):
-        """Consulta los certificados de un tipo (equivalente a GetListCsdByType en .NET)."""
         return CsdRequest.get_list_csd_by_type(self.get_url(), self.get_token(), certificate_type)
 
     def get_active_csd(self, rfc, certificate_type):
-        """Consulta el certificado activo de un RFC por tipo (equivalente a SearchActiveCsd en .NET)."""
         return CsdRequest.get_active_csd(self.get_url(), self.get_token(), rfc, certificate_type)

--- a/Csd/Csd.py
+++ b/Csd/Csd.py
@@ -7,3 +7,19 @@ class Csd(Services):
 
     def upload_csd(self, certificate_type, b64_cert, b64_key, password):
         return CsdRequest.upload_csd(self.get_url(), self.get_token(), certificate_type, b64_cert, b64_key, password)
+
+    def get_list_csd(self):
+        """Consulta todos los certificados de la cuenta (equivalente a GetListCsd en .NET)."""
+        return CsdRequest.get_list_csd(self.get_url(), self.get_token())
+
+    def get_csd(self, certificate_number):
+        """Consulta un certificado por su número de certificado (equivalente a SearchMyCsd en .NET)."""
+        return CsdRequest.get_csd(self.get_url(), self.get_token(), certificate_number)
+
+    def get_list_csd_by_rfc(self, rfc):
+        """Consulta los certificados de un RFC (equivalente a GetListCsdByRfc en .NET)."""
+        return CsdRequest.get_list_csd_by_rfc(self.get_url(), self.get_token(), rfc)
+
+    def disable_csd(self, certificate_number):
+        """Desactiva un certificado por su número de certificado (equivalente a DisableMyCsd en .NET)."""
+        return CsdRequest.disable_csd(self.get_url(), self.get_token(), certificate_number)

--- a/Csd/CsdRequest.py
+++ b/Csd/CsdRequest.py
@@ -51,3 +51,20 @@ class CsdRequest:
         endpoint = f"{url}/certificates/{certificate_number}"
         response = RequestHelper.delete_json_request(endpoint,token)
         return CsdResponse(response)
+
+    @staticmethod
+    def get_list_csd_by_type(url, token, certificate_type):
+        """Consulta los certificados de la cuenta que son de un tipo (stamp o fiel)."""
+        CsdRequest._validate_required(certificate_type, "Debe especificar el tipo de certificado")
+        endpoint = f"{url}/certificates/type/{certificate_type}"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return CsdResponse(response)
+
+    @staticmethod
+    def get_active_csd(url, token, rfc, certificate_type):
+        """Consulta el certificado activo de un RFC para un tipo (stamp o fiel)."""
+        CsdRequest._validate_required(rfc, "Debe especificar el RFC")
+        CsdRequest._validate_required(certificate_type, "Debe especificar el tipo de certificado")
+        endpoint = f"{url}/certificates/rfc/{rfc}/{certificate_type}"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return CsdResponse(response)

--- a/Csd/CsdRequest.py
+++ b/Csd/CsdRequest.py
@@ -15,13 +15,6 @@ class CsdRequest:
         return CsdResponse(response)
 
     @staticmethod
-    def _validate_required(value, message):
-        """Valida que un parámetro obligatorio no venga en None ni vacío.
-        Lanza ValueError antes de armar el endpoint y de ejecutar la petición."""
-        if value is None or not str(value).strip():
-            raise ValueError(message)
-
-    @staticmethod
     def get_list_csd(url, token):
         """Consulta todos los certificados de la cuenta asociada al token."""
         endpoint = url + "/certificates"
@@ -31,7 +24,6 @@ class CsdRequest:
     @staticmethod
     def get_csd(url, token, certificate_number):
         """Consulta un certificado por su número de certificado."""
-        CsdRequest._validate_required(certificate_number, "Debe especificar el número de certificado")
         endpoint = f"{url}/certificates/{certificate_number}"
         response = RequestHelper.get_json_request(endpoint,token)
         return CsdResponse(response)
@@ -39,7 +31,6 @@ class CsdRequest:
     @staticmethod
     def get_list_csd_by_rfc(url, token, rfc):
         """Consulta los certificados de la cuenta que pertenecen a un RFC."""
-        CsdRequest._validate_required(rfc, "Debe especificar el RFC")
         endpoint = f"{url}/certificates/rfc/{rfc}"
         response = RequestHelper.get_json_request(endpoint,token)
         return CsdResponse(response)
@@ -47,7 +38,6 @@ class CsdRequest:
     @staticmethod
     def disable_csd(url, token, certificate_number):
         """Desactiva (elimina) un certificado por su número de certificado."""
-        CsdRequest._validate_required(certificate_number, "Debe especificar el número de certificado")
         endpoint = f"{url}/certificates/{certificate_number}"
         response = RequestHelper.delete_json_request(endpoint,token)
         return CsdResponse(response)
@@ -55,7 +45,6 @@ class CsdRequest:
     @staticmethod
     def get_list_csd_by_type(url, token, certificate_type):
         """Consulta los certificados de la cuenta que son de un tipo (stamp o fiel)."""
-        CsdRequest._validate_required(certificate_type, "Debe especificar el tipo de certificado")
         endpoint = f"{url}/certificates/type/{certificate_type}"
         response = RequestHelper.get_json_request(endpoint,token)
         return CsdResponse(response)
@@ -63,8 +52,6 @@ class CsdRequest:
     @staticmethod
     def get_active_csd(url, token, rfc, certificate_type):
         """Consulta el certificado activo de un RFC para un tipo (stamp o fiel)."""
-        CsdRequest._validate_required(rfc, "Debe especificar el RFC")
-        CsdRequest._validate_required(certificate_type, "Debe especificar el tipo de certificado")
         endpoint = f"{url}/certificates/rfc/{rfc}/{certificate_type}"
         response = RequestHelper.get_json_request(endpoint,token)
         return CsdResponse(response)

--- a/Csd/CsdRequest.py
+++ b/Csd/CsdRequest.py
@@ -13,3 +13,41 @@ class CsdRequest:
         endpoint = url + "/certificates/save"
         response = RequestHelper.post_json_request(endpoint,token,payload)
         return CsdResponse(response)
+
+    @staticmethod
+    def _validate_required(value, message):
+        """Valida que un parámetro obligatorio no venga en None ni vacío.
+        Lanza ValueError antes de armar el endpoint y de ejecutar la petición."""
+        if value is None or not str(value).strip():
+            raise ValueError(message)
+
+    @staticmethod
+    def get_list_csd(url, token):
+        """Consulta todos los certificados de la cuenta asociada al token."""
+        endpoint = url + "/certificates"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return CsdResponse(response)
+
+    @staticmethod
+    def get_csd(url, token, certificate_number):
+        """Consulta un certificado por su número de certificado."""
+        CsdRequest._validate_required(certificate_number, "Debe especificar el número de certificado")
+        endpoint = f"{url}/certificates/{certificate_number}"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return CsdResponse(response)
+
+    @staticmethod
+    def get_list_csd_by_rfc(url, token, rfc):
+        """Consulta los certificados de la cuenta que pertenecen a un RFC."""
+        CsdRequest._validate_required(rfc, "Debe especificar el RFC")
+        endpoint = f"{url}/certificates/rfc/{rfc}"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return CsdResponse(response)
+
+    @staticmethod
+    def disable_csd(url, token, certificate_number):
+        """Desactiva (elimina) un certificado por su número de certificado."""
+        CsdRequest._validate_required(certificate_number, "Debe especificar el número de certificado")
+        endpoint = f"{url}/certificates/{certificate_number}"
+        response = RequestHelper.delete_json_request(endpoint,token)
+        return CsdResponse(response)

--- a/Csd/CsdResponse.py
+++ b/Csd/CsdResponse.py
@@ -11,6 +11,8 @@ class CsdResponse(Response):
                     self.status = self.response["status"]
                     self.data = self.response["data"]
                 else:
+                    if "status" in self.response:
+                        self.status = self.response["status"]
                     self.message = self.response["message"]
                     if "messageDetail" in self.response: 
                         self.messageDetail = self.response["messageDetail"]

--- a/Issue/IssueRequestV4.py
+++ b/Issue/IssueRequestV4.py
@@ -5,28 +5,41 @@ from typing import Optional, Dict, Union
 
 class IssueRequestV4:
     @staticmethod
-   
-    def issue_xml(url: str, token: str, xml: str, headers: Optional[Dict], version: ResponseVersion) -> IssueResponse:
-        """ Método estático para timbrar usando el servicio Emisión Timbrado XML V4 con soporte de versiones de respuesta."""
-        path = f"/v4/cfdi33/issue/{str(version)}"
+    def _build_headers(headers: Optional[Dict], email, custom_id: str, pdf: bool) -> Dict:
+        request_headers = {}
+        if email:
+            request_headers['email'] = ",".join(email) if isinstance(email, list) else email
+        if custom_id:
+            request_headers['customid'] = custom_id
+        if pdf:
+            request_headers['extra'] = "pdf"
+        if headers:
+            request_headers.update(headers)
+        return request_headers
+
+    @staticmethod
+    def issue_xml(url: str, token: str, xml: str, headers: Optional[Dict], version: ResponseVersion,
+                  email=None, custom_id: str = None, pdf: bool = False, b64: bool = False) -> IssueResponse:
+        bs64 = "/b64" if b64 else ""
+        path = f"/v4/cfdi33/issue/{str(version)}{bs64}"
         complete_url = f"{url}{path}"
         response = RequestHelper.post_v4(
             endpoint=complete_url,
             content=xml,
             token=token,
-            headers=headers
+            headers=IssueRequestV4._build_headers(headers, email, custom_id, pdf)
         )
         return IssueResponse(response)
 
     @staticmethod
-    def issue_json(url: str, token: str, json_data: Union[str, dict], headers: Optional[Dict], version: ResponseVersion) -> IssueResponse:
-        """" Método estático para timbrar usando el servicio Emisión Timbrado JSON V4 con soporte de versiones de respuesta."""
+    def issue_json(url: str, token: str, json_data: Union[str, dict], headers: Optional[Dict], version: ResponseVersion,
+                   email=None, custom_id: str = None, pdf: bool = False) -> IssueResponse:
         path = f"/v4/cfdi33/issue/json/{str(version)}"
         complete_url = f"{url}{path}"
         response = RequestHelper.post_v4_json(
             endpoint=complete_url,
             content=json_data,
             token=token,
-            headers=headers
+            headers=IssueRequestV4._build_headers(headers, email, custom_id, pdf)
         )
         return IssueResponse(response)

--- a/Issue/IssueV4.py
+++ b/Issue/IssueV4.py
@@ -8,20 +8,29 @@ class IssueV4(Services):
     def __init__(self, url: str, token: str = None, user: str = None, password: str = None):
         super(IssueV4, self).__init__(url, token, user, password)
 
-    def issue_xml(self, xml: str, headers: Optional[Dict] = None, version: ResponseVersion = ResponseVersion.V1) -> IssueResponse:
+    def issue_xml(self, xml: str, headers: Optional[Dict] = None, version: ResponseVersion = ResponseVersion.V1,
+                  email=None, custom_id: str = None, pdf: bool = False, b64: bool = False) -> IssueResponse:
         return IssueRequestV4.issue_xml(
             url=self.get_url(),
             token=self.get_token(),
             xml=xml,
             headers=headers,
-            version=version
+            version=version,
+            email=email,
+            custom_id=custom_id,
+            pdf=pdf,
+            b64=b64
         )
 
-    def issue_json(self, json_data: Union[str, dict], headers: Optional[Dict] = None, version: ResponseVersion = ResponseVersion.V1) -> IssueResponse:
+    def issue_json(self, json_data: Union[str, dict], headers: Optional[Dict] = None, version: ResponseVersion = ResponseVersion.V1,
+                   email=None, custom_id: str = None, pdf: bool = False) -> IssueResponse:
         return IssueRequestV4.issue_json(
             url=self.get_url(),
             token=self.get_token(),
             json_data=json_data,
             headers=headers,
-            version=version
+            version=version,
+            email=email,
+            custom_id=custom_id,
+            pdf=pdf
         )

--- a/Pdf/Pdf.py
+++ b/Pdf/Pdf.py
@@ -12,5 +12,11 @@ class Pdf(Services):
     
     def generate_pdf(self,xml, b64Logo, template_id, extras):
         return PdfRequest.generate_pdf(self.urlApi, self.get_token(),xml, b64Logo, template_id, extras)
-    
+
+    def regenerate_pdf(self, uuid, b64Logo=None, template_id=None, extras=None):
+        """Regenera el PDF de un comprobante previamente timbrado y lo guarda o
+        reemplaza en el Administrador de Timbres. El uuid se acepta como cadena o
+        como uuid.UUID."""
+        return PdfRequest.regenerate_pdf(self.urlApi, self.get_token(), uuid, b64Logo, template_id, extras)
+
     

--- a/Pdf/Pdf.py
+++ b/Pdf/Pdf.py
@@ -14,9 +14,6 @@ class Pdf(Services):
         return PdfRequest.generate_pdf(self.urlApi, self.get_token(),xml, b64Logo, template_id, extras)
 
     def regenerate_pdf(self, uuid, b64Logo=None, template_id=None, extras=None):
-        """Regenera el PDF de un comprobante previamente timbrado y lo guarda o
-        reemplaza en el Administrador de Timbres. El uuid se acepta como cadena o
-        como uuid.UUID."""
         return PdfRequest.regenerate_pdf(self.urlApi, self.get_token(), uuid, b64Logo, template_id, extras)
 
     

--- a/Pdf/PdfRequest.py
+++ b/Pdf/PdfRequest.py
@@ -1,4 +1,5 @@
 from Pdf.PdfResponse import PdfResponse
+from Pdf.RegeneratePdfResponse import RegeneratePdfResponse
 from Utils.requestHelper import RequestHelper
 
 class PdfRequest():
@@ -8,4 +9,19 @@ class PdfRequest():
         endpoint = urlApi + "/pdf/v1/api/GeneratePdf"
         response = RequestHelper.post_json_request(endpoint,token,payload)
         return PdfResponse(response)
-    
+
+    @staticmethod
+    def regenerate_pdf(urlApi, token, uuid, b64Logo=None, template_id=None, extras=None):
+        """Regenera el PDF de un comprobante timbrado y lo reemplaza en el ADT.
+        Todos los datos del cuerpo son opcionales: sólo se envían los informados.
+        El formato del UUID no se valida en local, se envía tal cual y responde el servicio."""
+        payload = {}
+        if b64Logo is not None:
+            payload['logo'] = b64Logo
+        if template_id is not None:
+            payload['templateId'] = template_id
+        if extras is not None:
+            payload['extras'] = extras
+        endpoint = urlApi + "/pdf/v1/api/RegeneratePdf/" + str(uuid)
+        response = RequestHelper.post_json_request(endpoint,token,payload)
+        return RegeneratePdfResponse(response)

--- a/Pdf/PdfRequest.py
+++ b/Pdf/PdfRequest.py
@@ -12,9 +12,6 @@ class PdfRequest():
 
     @staticmethod
     def regenerate_pdf(urlApi, token, uuid, b64Logo=None, template_id=None, extras=None):
-        """Regenera el PDF de un comprobante timbrado y lo reemplaza en el ADT.
-        Todos los datos del cuerpo son opcionales: sólo se envían los informados.
-        El formato del UUID no se valida en local, se envía tal cual y responde el servicio."""
         payload = {}
         if b64Logo is not None:
             payload['logo'] = b64Logo

--- a/Pdf/RegeneratePdfResponse.py
+++ b/Pdf/RegeneratePdfResponse.py
@@ -2,8 +2,6 @@ import json
 import traceback
 from Utils.response import Response
 
-#La regeneración de PDF sólo regresa un mensaje: la respuesta no trae las llaves
-#status ni data, por eso no puede reutilizar PdfResponse.
 class RegeneratePdfResponse(Response):
     def __init__(self, response):
         try:
@@ -17,7 +15,6 @@ class RegeneratePdfResponse(Response):
                     if "messageDetail" in self.response:
                         self.messageDetail = self.response["messageDetail"]
                 except ValueError:
-                    #Un cuerpo que no es JSON se conserva tal cual en message.
                     self.message = response.text
             else:
                 self.message = response.reason

--- a/Pdf/RegeneratePdfResponse.py
+++ b/Pdf/RegeneratePdfResponse.py
@@ -1,0 +1,25 @@
+import json
+import traceback
+from Utils.response import Response
+
+#La regeneración de PDF sólo regresa un mensaje: la respuesta no trae las llaves
+#status ni data, por eso no puede reutilizar PdfResponse.
+class RegeneratePdfResponse(Response):
+    def __init__(self, response):
+        try:
+            self.status_code = response.status_code
+            self.status = "success" if self.status_code == 200 else "error"
+            if(bool(response.text and response.text.strip())):
+                try:
+                    self.response = json.loads(response.text.encode().decode('utf8'))
+                    if "message" in self.response:
+                        self.message = self.response["message"]
+                    if "messageDetail" in self.response:
+                        self.messageDetail = self.response["messageDetail"]
+                except ValueError:
+                    #Un cuerpo que no es JSON se conserva tal cual en message.
+                    self.message = response.text
+            else:
+                self.message = response.reason
+        except:
+            traceback.print_exc()

--- a/README.md
+++ b/README.md
@@ -1731,6 +1731,7 @@ else:
 	for certificado in response.get_data():
 		print("issuer_rfc: ", certificado["issuer_rfc"])
 		print("certificate_number: ", certificado["certificate_number"])
+		print("csd_certificate: ", certificado["csd_certificate"])
 		print("is_active: ", certificado["is_active"])
 		print("issuer_business_name: ", certificado["issuer_business_name"])
 		print("valid_from: ", certificado["valid_from"])
@@ -1780,6 +1781,7 @@ else:
 	certificado = response.get_data()
 	print("issuer_rfc: ", certificado["issuer_rfc"])
 	print("certificate_number: ", certificado["certificate_number"])
+	print("csd_certificate: ", certificado["csd_certificate"])
 	print("is_active: ", certificado["is_active"])
 	print("issuer_business_name: ", certificado["issuer_business_name"])
 	print("valid_from: ", certificado["valid_from"])

--- a/README.md
+++ b/README.md
@@ -2177,7 +2177,6 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-#El listado de correos tambien se acepta como lista
 response = issue.issue_xml(xml_content, email=["test1@test.com", "test2@test.com"], version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
@@ -2316,8 +2315,6 @@ print(response.get_data())
 print(response.get_status())
 ```
 </details>
-
-:pushpin: ***NOTA:*** El PDF no viene en la respuesta del timbrado: se guarda en el ADT y su URL de descarga se obtiene con [Recuperar XML por UUID](#recuperar-xml-por-uuid). Si necesita el contenido del PDF en la respuesta, el servicio correspondiente es [Generar PDF](#pdf).
 
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -2087,9 +2087,7 @@ else:
 
 :pushpin: ***NOTA:*** El comprobante tarda alrededor de un minuto en quedar disponible en la consulta después de timbrarse. Durante ese lapso la respuesta es `success` con `records` vacío.
 
-:pushpin: ***NOTA:*** El campo con la url del PDF viene como `urlPDF`. El método `get_url_pdf()` contempla también la variante `urlPdf`, y si se recorren los registros directamente conviene usar `.get()` para no depender del casing. El campo llega vacío mientras no se haya generado el PDF del comprobante.
-
-:pushpin: ***NOTA:*** Las pruebas unitarias de este servicio (`Test/test_storage.py`) requieren la variable de entorno `SDKTEST_UUID` con el UUID de un CFDI timbrado en la cuenta de pruebas, además de las ya conocidas `SDKTEST_USER`, `SDKTEST_PASSWORD` y `SDKTEST_TOKEN`.
+:pushpin: ***NOTA:*** `get_url_pdf()` regresa vacío mientras no se haya generado el PDF del comprobante.
 
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.

--- a/README.md
+++ b/README.md
@@ -2133,6 +2133,15 @@ else:
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.
 
+Los tres métodos (`StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`) reciben los mismos parámetros opcionales:
+
+* `email`: uno o varios correos a los que se enviará el XML timbrado, como cadena separada por comas o como lista.
+* `custom_id`: identificador asignado por el usuario para evitar la duplicidad de timbrado.
+* `pdf`: con el valor `True` confirma la generación del PDF, que se guarda en automático en el ADT.
+* `b64`: con el valor `True` indica que el XML se envía en base 64. No aplica en `issue_json`.
+* `headers`: diccionario de headers, que se sigue recibiendo. Sus valores prevalecen sobre los parámetros anteriores.
+* `version`: versión de la respuesta, tomada del enum `ResponseVersion` (`V1`, `V2`, `V3` y `V4`). Puede consultar el detalle de cada versión en el siguiente [link](https://developers.sw.com.mx/knowledge-base/versiones-de-respuesta-timbrado/).
+
 ### **Email** ###
 
 Este servicio recibe un comprobante CFDI para ser timbrado y recibe un listado de uno o hasta 5 correos electrónicos a los que se requiera enviar el XML timbrado.
@@ -2146,14 +2155,12 @@ Existen varias versiones de respuesta a este método, las cuales puede consultar
 ```py
 from Stamp.StampV4 import StampV4
 from Utils.response_version import ResponseVersion
+
 #Creamos funcion para abrir nuestro archivo
- xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
- stamp = StampV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
- headers = {
-                "email": "stamp1@test.com,stamp2@test.com"
-           }
-response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
+stamp = StampV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
+response = stamp.stamp(xml_content, email="stamp1@test.com,stamp2@test.com", version=ResponseVersion.V2)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2167,16 +2174,13 @@ print(response.get_status())
 ```py
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
-issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
-             xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-            
-           headers = {
-                "email": "test1@test.com,test2@test.com"
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            print(response.get_data())
-            print(response.get_status())
+
+issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+#El listado de correos tambien se acepta como lista
+response = issue.issue_xml(xml_content, email=["test1@test.com", "test2@test.com"], version=ResponseVersion.V4)
+print(response.get_data())
+print(response.get_status())
 ```
 
 </details>
@@ -2189,16 +2193,11 @@ issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealT
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
 
-            issue = IssueV4("http://services.test.sw.com.mx", None, "user", "password")
-            json_content =  open_file("cfdi.json")
-            
-            headers = {
-                "email": "test1@test.com,test2@test.com"
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
-            print(response.get_data())
-            print(response.get_status())
+issue = IssueV4("https://services.test.sw.com.mx", None, "user", "password")
+json_content = open("cfdi.json", "r", encoding='utf-8').read()
+response = issue.issue_json(json_content, email="test1@test.com,test2@test.com", version=ResponseVersion.V4)
+print(response.get_data())
+print(response.get_status())
 ```
 </details>
 
@@ -2215,14 +2214,12 @@ Existen varias versiones de respuesta a este método, las cuales puede consultar
 ```py
 from Stamp.StampV4 import StampV4
 from Utils.response_version import ResponseVersion
+
 #Creamos funcion para abrir nuestro archivo
- xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
- stamp = StampV4("http://services.test.sw.com.mx",None, "user", "password")
- headers = {
-                 "customid": "ISS-25-369"
-           }
-response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V3)
+stamp = StampV4("https://services.test.sw.com.mx",None, "user", "password")
+response = stamp.stamp(xml_content, custom_id="ISS-25-369", version=ResponseVersion.V3)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2235,16 +2232,12 @@ print(response.get_status())
 ```py
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
-issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
-             xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-            
-           headers = {
-                  "customid": "ISS-25-368"
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            print(response.get_data())
-            print(response.get_status())
+
+issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+response = issue.issue_xml(xml_content, custom_id="ISS-25-368", version=ResponseVersion.V4)
+print(response.get_data())
+print(response.get_status())
 ```
 
 </details>
@@ -2257,16 +2250,11 @@ issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealT
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
 
-            issue = IssueV4("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
-            json_content =  open_file("cfdi.json")
-            
-            headers = {
-                  "customid": "ISS-25-369"
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V1)
-            print(response.get_data())
-            print(response.get_status())
+issue = IssueV4("https://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+json_content = open("cfdi.json", "r", encoding='utf-8').read()
+response = issue.issue_json(json_content, custom_id="ISS-25-369", version=ResponseVersion.V1)
+print(response.get_data())
+print(response.get_status())
 ```
 </details>
 
@@ -2284,14 +2272,12 @@ Existen varias versiones de respuesta a este método, las cuales puede consultar
 ```py
 from Stamp.StampV4 import StampV4
 from Utils.response_version import ResponseVersion
+
 #Creamos funcion para abrir nuestro archivo
- xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
- stamp = StampV4("http://services.test.sw.com.mx",None, "user", "password")
- headers = {
-                 "pdf": "true"
-           }
-response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
+stamp = StampV4("https://services.test.sw.com.mx",None, "user", "password")
+response = stamp.stamp(xml_content, pdf=True, version=ResponseVersion.V2)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2304,16 +2290,12 @@ print(response.get_status())
 ```py
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
-issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
-             xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-            
-           headers = {
-                   "pdf": "true"
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            print(response.get_data())
-            print(response.get_status())
+
+issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
+xml_content = open("prueba.xml", "r", encoding='utf-8').read()
+response = issue.issue_xml(xml_content, pdf=True, version=ResponseVersion.V4)
+print(response.get_data())
+print(response.get_status())
 ```
 
 </details>
@@ -2327,18 +2309,15 @@ issue = IssueV4("http://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealT
 from Issue.IssueV4 import IssueV4
 from Utils.response_version import ResponseVersion
 
-            issue = IssueV4("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
-            json_content =  open_file("cfdi.json")
-            
-            headers = {
-                  "pdf": "true"
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
-            print(response.get_data())
-            print(response.get_status())
+issue = IssueV4("https://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+json_content = open("cfdi.json", "r", encoding='utf-8').read()
+response = issue.issue_json(json_content, pdf=True, version=ResponseVersion.V4)
+print(response.get_data())
+print(response.get_status())
 ```
 </details>
+
+:pushpin: ***NOTA:*** El PDF no viene en la respuesta del timbrado: se guarda en el ADT y su URL de descarga se obtiene con [Recuperar XML por UUID](#recuperar-xml-por-uuid). Si necesita el contenido del PDF en la respuesta, el servicio correspondiente es [Generar PDF](#pdf).
 
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -2133,13 +2133,17 @@ else:
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.
 
-Los tres métodos (`StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`) reciben los mismos parámetros opcionales:
+Los tres métodos (`StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`) reciben los headers en el parámetro `headers` y esa es la forma de consumo de referencia, la que usan los ejemplos de esta sección: los nombres de los headers se documentan aquí, de modo que si el servicio agrega o cambia alguno basta con actualizar esta documentación. Los headers disponibles son:
 
-* `email`: uno o varios correos a los que se enviará el XML timbrado, como cadena separada por comas o como lista.
-* `custom_id`: identificador asignado por el usuario para evitar la duplicidad de timbrado.
-* `pdf`: con el valor `True` confirma la generación del PDF, que se guarda en automático en el ADT.
+* `email`: uno o varios correos, separados por comas, a los que se enviará el XML timbrado.
+* `customid`: identificador asignado por el usuario para evitar la duplicidad de timbrado.
+* `extra`: con el valor `pdf` confirma la generación del PDF, que se guarda en automático en el ADT.
+
+Como atajo para esos tres headers, los mismos métodos aceptan los parámetros `email`, `custom_id` y `pdf`, que los arman internamente; `email` acepta también una lista y `pdf` es un booleano. Si se envían las dos formas al mismo tiempo, prevalece el contenido de `headers`.
+
+Los tres métodos reciben además:
+
 * `b64`: con el valor `True` indica que el XML se envía en base 64. No aplica en `issue_json`.
-* `headers`: diccionario de headers, que se sigue recibiendo. Sus valores prevalecen sobre los parámetros anteriores.
 * `version`: versión de la respuesta, tomada del enum `ResponseVersion` (`V1`, `V2`, `V3` y `V4`). Puede consultar el detalle de cada versión en el siguiente [link](https://developers.sw.com.mx/knowledge-base/versiones-de-respuesta-timbrado/).
 
 ### **Email** ###
@@ -2160,7 +2164,10 @@ from Utils.response_version import ResponseVersion
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
 stamp = StampV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
-response = stamp.stamp(xml_content, email="stamp1@test.com,stamp2@test.com", version=ResponseVersion.V2)
+headers = {
+    "email": "stamp1@test.com,stamp2@test.com"
+}
+response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2177,7 +2184,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-response = issue.issue_xml(xml_content, email=["test1@test.com", "test2@test.com"], version=ResponseVersion.V4)
+headers = {
+    "email": "test1@test.com,test2@test.com"
+}
+response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2194,7 +2204,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx", None, "user", "password")
 json_content = open("cfdi.json", "r", encoding='utf-8').read()
-response = issue.issue_json(json_content, email="test1@test.com,test2@test.com", version=ResponseVersion.V4)
+headers = {
+    "email": "test1@test.com,test2@test.com"
+}
+response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2218,7 +2231,10 @@ from Utils.response_version import ResponseVersion
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
 stamp = StampV4("https://services.test.sw.com.mx",None, "user", "password")
-response = stamp.stamp(xml_content, custom_id="ISS-25-369", version=ResponseVersion.V3)
+headers = {
+    "customid": "ISS-25-369"
+}
+response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V3)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2234,7 +2250,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-response = issue.issue_xml(xml_content, custom_id="ISS-25-368", version=ResponseVersion.V4)
+headers = {
+    "customid": "ISS-25-368"
+}
+response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2251,7 +2270,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
 json_content = open("cfdi.json", "r", encoding='utf-8').read()
-response = issue.issue_json(json_content, custom_id="ISS-25-369", version=ResponseVersion.V1)
+headers = {
+    "customid": "ISS-25-369"
+}
+response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V1)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2276,7 +2298,10 @@ from Utils.response_version import ResponseVersion
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
 #Creamos instancia y pasamos parametros
 stamp = StampV4("https://services.test.sw.com.mx",None, "user", "password")
-response = stamp.stamp(xml_content, pdf=True, version=ResponseVersion.V2)
+headers = {
+    "extra": "pdf"
+}
+response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2292,7 +2317,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
 xml_content = open("prueba.xml", "r", encoding='utf-8').read()
-response = issue.issue_xml(xml_content, pdf=True, version=ResponseVersion.V4)
+headers = {
+    "extra": "pdf"
+}
+response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
 ```
@@ -2310,7 +2338,10 @@ from Utils.response_version import ResponseVersion
 
 issue = IssueV4("https://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
 json_content = open("cfdi.json", "r", encoding='utf-8').read()
-response = issue.issue_json(json_content, pdf=True, version=ResponseVersion.V4)
+headers = {
+    "extra": "pdf"
+}
+response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
 print(response.get_data())
 print(response.get_status())
 ```

--- a/README.md
+++ b/README.md
@@ -2133,13 +2133,13 @@ else:
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.
 
-Los tres métodos (`StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`) reciben los headers en el parámetro `headers` y esa es la forma de consumo de referencia, la que usan los ejemplos de esta sección: los nombres de los headers se documentan aquí, de modo que si el servicio agrega o cambia alguno basta con actualizar esta documentación. Los headers disponibles son:
+Los tres métodos (`StampV4.stamp`, `IssueV4.issue_xml` e `IssueV4.issue_json`) reciben los headers en el parámetro `headers`. Los headers disponibles son:
 
-* `email`: uno o varios correos, separados por comas, a los que se enviará el XML timbrado.
+* `email`: hasta 5 correos, separados por comas, a los que se enviará el XML timbrado.
 * `customid`: identificador asignado por el usuario para evitar la duplicidad de timbrado.
 * `extra`: con el valor `pdf` confirma la generación del PDF, que se guarda en automático en el ADT.
 
-Como atajo para esos tres headers, los mismos métodos aceptan los parámetros `email`, `custom_id` y `pdf`, que los arman internamente; `email` acepta también una lista y `pdf` es un booleano. Si se envían las dos formas al mismo tiempo, prevalece el contenido de `headers`.
+Esos tres headers también se pueden enviar con los parámetros `email`, `custom_id` y `pdf`, que los arman internamente; `email` acepta además una lista y `pdf` es un booleano. Si se usan las dos formas al mismo tiempo, prevalece el contenido de `headers`.
 
 Los tres métodos reciben además:
 

--- a/README.md
+++ b/README.md
@@ -2010,7 +2010,7 @@ Este metodo recibe los siguientes parametros:
 * Url Servicios SW
 * Url Api
 * Token
-* UUID del CFDI
+* UUID del CFDI, como cadena o como `uuid.UUID`
 
 **Ejemplo de consumo de la libreria para la recuperación de un XML mediante token**
 ```py
@@ -2025,7 +2025,8 @@ if response.get_status() ==  "error":
 	print(response.get_messageDetail())
 else:
 	print(response.get_status())
-	#Un UUID sin coincidencias regresa una lista vacía.
+	#Un UUID sin coincidencias regresa una lista vacía. El comprobante recién timbrado
+	#tarda alrededor de un minuto en quedar disponible en la consulta.
 	for registro in response.get_records():
 		print("UUID: ", registro.get("uuid"))
 		print("Serie: ", registro.get("serie"))
@@ -2060,7 +2061,7 @@ Este metodo recibe los siguientes parametros:
 * Url Servicios SW
 * Url Api
 * Usuario y contraseña
-* UUID del CFDI
+* UUID del CFDI, como cadena o como `uuid.UUID`
 
 **Ejemplo de consumo de la libreria para la recuperación de un XML mediante usuario y contraseña**
 ```py
@@ -2078,16 +2079,6 @@ else:
 	print("Url de descarga del XML: ", response.get_url_xml())
 ```
 </details>
-
-:pushpin: ***NOTA:*** La url base de este servicio es la de la **API** (`https://api.test.sw.com.mx`), no la de servicios. La url de servicios sólo se utiliza para autenticar con usuario y contraseña.
-
-:pushpin: ***NOTA:*** Si el UUID no existe, está mal escrito o no fue timbrado con la cuenta autenticada, el servicio responde `status` **success** con `records` vacío. Esto no es un error: se consulta con `get_records()`, que regresa una lista vacía, o con `get_first_record()`, que regresa `None`.
-
-:pushpin: ***NOTA:*** El UUID puede enviarse como cadena o como `uuid.UUID`. La librería no valida el formato en local: se envía tal cual y responde el servicio.
-
-:pushpin: ***NOTA:*** El comprobante tarda alrededor de un minuto en quedar disponible en la consulta después de timbrarse. Durante ese lapso la respuesta es `success` con `records` vacío.
-
-:pushpin: ***NOTA:*** `get_url_pdf()` regresa vacío mientras no se haya generado el PDF del comprobante.
 
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.

--- a/README.md
+++ b/README.md
@@ -1996,6 +1996,90 @@ print(response.get_data())
 :pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
+## Recuperar XML por UUID ##
+Servicio para recuperar la información y las URLs de descarga de un CFDI timbrado con SW a partir de su UUID.
+
+<details>
+<summary>
+Recuperar XML por UUID mediante token
+</summary>
+
+Método para consultar un CFDI timbrado en la cuenta mediante su UUID.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Url Api
+* Token
+* UUID del CFDI
+
+**Ejemplo de consumo de la libreria para la recuperación de un XML mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Storage.Storage import Storage
+
+storage_obj = Storage("https://services.test.sw.com.mx", "https://api.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = storage_obj.get_by_uuid("d3773788-c68a-4549-ac67-f223d26c925b")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	print(response.get_status())
+	#Un UUID sin coincidencias regresa una lista vacía.
+	for registro in response.get_records():
+		print("UUID: ", registro.get("uuid"))
+		print("Serie: ", registro.get("serie"))
+		print("Folio: ", registro.get("folio"))
+		print("Total: ", registro.get("total"))
+		print("RFC Emisor: ", registro.get("rfcEmisor"))
+		print("RFC Receptor: ", registro.get("rfcReceptor"))
+		print("Url XML: ", registro.get("urlXml"))
+	#Atajos para el primer registro de la consulta
+	print("Url de descarga del XML: ", response.get_url_xml())
+	print("Url de descarga del PDF: ", response.get_url_pdf())
+```
+</details>
+
+<details>
+<summary>
+Recuperar XML por UUID mediante usuario y contraseña
+</summary>
+
+Método para consultar un CFDI timbrado en la cuenta mediante su UUID, autenticando con usuario y contraseña.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Url Api
+* Usuario y contraseña
+* UUID del CFDI
+
+**Ejemplo de consumo de la libreria para la recuperación de un XML mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Storage.Storage import Storage
+
+storage_obj = Storage("https://services.test.sw.com.mx", "https://api.test.sw.com.mx", None, "user", "password")
+response = storage_obj.get_by_uuid("d3773788-c68a-4549-ac67-f223d26c925b")
+
+print(response.get_status())
+registro = response.get_first_record()
+if registro is None:
+	print("El UUID no se encontró en la cuenta")
+else:
+	print("Url de descarga del XML: ", response.get_url_xml())
+```
+</details>
+
+:pushpin: ***NOTA:*** La url base de este servicio es la de la **API** (`https://api.test.sw.com.mx`), no la de servicios. La url de servicios sólo se utiliza para autenticar con usuario y contraseña.
+
+:pushpin: ***NOTA:*** Si el UUID no existe, está mal escrito o no fue timbrado con la cuenta autenticada, el servicio responde `status` **success** con `records` vacío. Esto no es un error: se consulta con `get_records()`, que regresa una lista vacía, o con `get_first_record()`, que regresa `None`.
+
+:pushpin: ***NOTA:*** El UUID puede enviarse como cadena o como `uuid.UUID`. La librería no valida el formato en local: se envía tal cual y responde el servicio.
+
+:pushpin: ***NOTA:*** La documentación oficial nombra el campo del PDF como `urlPDF` y el SDK de .NET como `urlPdf`. El método `get_url_pdf()` contempla ambas variantes; si se recorren los registros directamente conviene usar `.get()` para no depender del casing.
+
+:pushpin: ***NOTA:*** Las pruebas unitarias de este servicio (`Test/test_storage.py`) requieren la variable de entorno `SDKTEST_UUID` con el UUID de un CFDI timbrado en la cuenta de pruebas, además de las ya conocidas `SDKTEST_USER`, `SDKTEST_PASSWORD` y `SDKTEST_TOKEN`.
+
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.
 

--- a/README.md
+++ b/README.md
@@ -2039,6 +2039,13 @@ else:
 	#Atajos para el primer registro de la consulta
 	print("Url de descarga del XML: ", response.get_url_xml())
 	print("Url de descarga del PDF: ", response.get_url_pdf())
+	#Descargamos el XML
+	if response.get_url_xml():
+		import requests
+		xml = requests.get(response.get_url_xml()).content
+		f = open('file.xml', 'wb')
+		f.write(xml)
+		f.close()
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1675,6 +1675,56 @@ f.close()
 Para mayor referencia de estas plantillas de PDF, favor de visitar el siguiente [link](https://developers.sw.com.mx/knowledge-base/plantillas-pdf/).
 </details>
 
+<details>
+<summary>
+Regenerar PDF
+</summary>
+
+Este método genera o regenera el PDF de un CFDI previamente timbrado y lo guarda o reemplaza en el Administrador de Timbres. Puede ser consumido ingresando tu usuario y contraseña así como tambien ingresando solo el token. Este método recibe los siguientes parámetros:
+
+* Url servicios SW
+* Url Api
+* Usuario y contraseña o Token
+* UUID del CFDI, como cadena o como `uuid.UUID`
+* Logo en base 64 (opcional)
+* Template id (opcional), se solicita a Soporte Técnico cuando se trata de una plantilla personalizada
+* Datos extra (opcional), sólo aplica en plantillas personalizadas
+
+**Ejemplo de consumo de la libreria para la regeneración de PDF mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Pdf.Pdf import Pdf
+
+pdf = Pdf("https://services.test.sw.com.mx","https://api.test.sw.com.mx","T2lYQ0t4L0R....ReplaceForRealToken")
+response = pdf.regenerate_pdf("d3773788-c68a-4549-ac67-f223d26c925b")
+
+if response.get_status() == "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	print(response.get_status())
+	print(response.get_message())
+```
+
+**Ejemplo de consumo de la libreria para la regeneración de PDF mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Pdf.Pdf import Pdf
+
+#Datos opcionales para una plantilla personalizada
+logo = None
+extras = {
+        'REFERENCIA': "Referencia de pruebas"
+        }
+pdf = Pdf("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, "user", "password")
+response = pdf.regenerate_pdf("d3773788-c68a-4549-ac67-f223d26c925b", logo, "cfdi40", extras)
+print(response.get_status())
+print(response.get_message())
+```
+
+:pushpin: ***NOTA:*** Este servicio no devuelve el PDF en base 64, únicamente el mensaje de confirmación, y el archivo queda almacenado o reemplazado en el Administrador de Timbres. Si se necesita el contenido del PDF en la respuesta, el servicio correspondiente es **Generar PDF**; las URLs de descarga del comprobante ya regenerado se obtienen con [Recuperar XML por UUID](#recuperar-xml-por-uuid).
+</details>
+
 ## Certificados ##
 Servicio para gestionar los certificados CSD de tu cuenta.
 Para administrar los certificados de manera gráfica, puede hacerlo desde el [Administrador de timbres](https://portal.sw.com.mx/).

--- a/README.md
+++ b/README.md
@@ -1801,7 +1801,7 @@ print(response.get_data())
 
 :pushpin: ***NOTA:*** A diferencia de la consulta general, aquí `data` es un objeto único, no un arreglo.
 
-:pushpin: ***NOTA:*** Si el número de certificado viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el número de certificado")` sin ejecutar la petición.
+:pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
 <details>
@@ -1846,7 +1846,7 @@ print(response.get_status())
 print(response.get_data())
 ```
 
-:pushpin: ***NOTA:*** Si el RFC viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el RFC")` sin ejecutar la petición.
+:pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
 <details>
@@ -1894,7 +1894,7 @@ print(response.get_data())
 
 :pushpin: ***NOTA:*** Si no hay certificados de ese tipo, el servicio responde `status` **success** con `data` vacío; no se trata de un error.
 
-:pushpin: ***NOTA:*** Si el tipo viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el tipo de certificado")` sin ejecutar la petición.
+:pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
 <details>
@@ -1946,7 +1946,7 @@ print(response.get_data())
 
 :pushpin: ***NOTA:*** Si el RFC no tiene un certificado activo de ese tipo, el servicio responde `status` **error**.
 
-:pushpin: ***NOTA:*** Si el RFC o el tipo vienen vacíos o en `None`, la librería lanza `ValueError` sin ejecutar la petición.
+:pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
 <details>
@@ -1991,7 +1991,7 @@ print(response.get_data())
 
 :pushpin: ***NOTA:*** La operación desactiva el certificado en la cuenta. Para volver a utilizarlo es necesario cargarlo de nuevo con **Cargar Certificado**.
 
-:pushpin: ***NOTA:*** Si el número de certificado viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el número de certificado")` sin ejecutar la petición.
+:pushpin: ***NOTA:*** El parámetro es obligatorio. La librería no lo valida en local: se envía tal cual y responde el servicio.
 </details>
 
 ## TimbradoV4 ##

--- a/README.md
+++ b/README.md
@@ -2030,9 +2030,11 @@ else:
 		print("UUID: ", registro.get("uuid"))
 		print("Serie: ", registro.get("serie"))
 		print("Folio: ", registro.get("folio"))
+		print("Fecha: ", registro.get("fecha"))
 		print("Total: ", registro.get("total"))
-		print("RFC Emisor: ", registro.get("rfcEmisor"))
-		print("RFC Receptor: ", registro.get("rfcReceptor"))
+		print("Emisor: ", registro.get("emisorRfc"), registro.get("emisorNombre"))
+		print("Receptor: ", registro.get("receptorRfc"), registro.get("receptorNombre"))
+		print("Estatus SAT: ", registro.get("statusSAT"))
 		print("Url XML: ", registro.get("urlXml"))
 	#Atajos para el primer registro de la consulta
 	print("Url de descarga del XML: ", response.get_url_xml())
@@ -2076,7 +2078,9 @@ else:
 
 :pushpin: ***NOTA:*** El UUID puede enviarse como cadena o como `uuid.UUID`. La librería no valida el formato en local: se envía tal cual y responde el servicio.
 
-:pushpin: ***NOTA:*** La documentación oficial nombra el campo del PDF como `urlPDF` y el SDK de .NET como `urlPdf`. El método `get_url_pdf()` contempla ambas variantes; si se recorren los registros directamente conviene usar `.get()` para no depender del casing.
+:pushpin: ***NOTA:*** El comprobante tarda alrededor de un minuto en quedar disponible en la consulta después de timbrarse. Durante ese lapso la respuesta es `success` con `records` vacío.
+
+:pushpin: ***NOTA:*** El campo con la url del PDF viene como `urlPDF`; el SDK de .NET lo nombra `urlPdf`. El método `get_url_pdf()` contempla ambas variantes, y si se recorren los registros directamente conviene usar `.get()` para no depender del casing. El campo llega vacío mientras no se haya generado el PDF del comprobante.
 
 :pushpin: ***NOTA:*** Las pruebas unitarias de este servicio (`Test/test_storage.py`) requieren la variable de entorno `SDKTEST_UUID` con el UUID de un CFDI timbrado en la cuenta de pruebas, además de las ya conocidas `SDKTEST_USER`, `SDKTEST_PASSWORD` y `SDKTEST_TOKEN`.
 

--- a/README.md
+++ b/README.md
@@ -1851,6 +1851,106 @@ print(response.get_data())
 
 <details>
 <summary>
+Consultar Certificados por Tipo
+</summary>
+
+Método para consultar los certificados de la cuenta que corresponden a un tipo, **stamp** o **fiel**.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+* Tipo de certificado
+
+**Ejemplo de consumo de la libreria para la consulta de certificados por tipo mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.get_list_csd_by_type("stamp")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	for certificado in response.get_data():
+		print("certificate_number: ", certificado["certificate_number"])
+		print("issuer_rfc: ", certificado["issuer_rfc"])
+		print("certificate_type: ", certificado["certificate_type"])
+		print("is_active: ", certificado["is_active"])
+```
+
+**Ejemplo de consumo de la libreria para la consulta de certificados por tipo mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.get_list_csd_by_type("stamp")
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** Si no hay certificados de ese tipo, el servicio responde `status` **success** con `data` vacío; no se trata de un error.
+
+:pushpin: ***NOTA:*** Si el tipo viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el tipo de certificado")` sin ejecutar la petición.
+</details>
+
+<details>
+<summary>
+Consultar Certificado Activo por RFC
+</summary>
+
+Método para consultar el certificado **activo** de un RFC para un tipo determinado, **stamp** o **fiel**.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+* RFC del emisor
+* Tipo de certificado
+
+**Ejemplo de consumo de la libreria para la consulta del certificado activo mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.get_active_csd("EKU9003173C9", "stamp")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	certificado = response.get_data()
+	print("certificate_number: ", certificado["certificate_number"])
+	print("issuer_business_name: ", certificado["issuer_business_name"])
+	print("valid_from: ", certificado["valid_from"])
+	print("valid_to: ", certificado["valid_to"])
+	print("is_active: ", certificado["is_active"])
+```
+
+**Ejemplo de consumo de la libreria para la consulta del certificado activo mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.get_active_csd("EKU9003173C9", "stamp")
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** A diferencia de la consulta por RFC, aquí `data` es un objeto único con el certificado activo, no un arreglo.
+
+:pushpin: ***NOTA:*** Si el RFC no tiene un certificado activo de ese tipo, el servicio responde `status` **error**.
+
+:pushpin: ***NOTA:*** Si el RFC o el tipo vienen vacíos o en `None`, la librería lanza `ValueError` sin ejecutar la petición.
+</details>
+
+<details>
+<summary>
 Eliminar Certificado
 </summary>
 

--- a/README.md
+++ b/README.md
@@ -2087,7 +2087,7 @@ else:
 
 :pushpin: ***NOTA:*** El comprobante tarda alrededor de un minuto en quedar disponible en la consulta después de timbrarse. Durante ese lapso la respuesta es `success` con `records` vacío.
 
-:pushpin: ***NOTA:*** El campo con la url del PDF viene como `urlPDF`; el SDK de .NET lo nombra `urlPdf`. El método `get_url_pdf()` contempla ambas variantes, y si se recorren los registros directamente conviene usar `.get()` para no depender del casing. El campo llega vacío mientras no se haya generado el PDF del comprobante.
+:pushpin: ***NOTA:*** El campo con la url del PDF viene como `urlPDF`. El método `get_url_pdf()` contempla también la variante `urlPdf`, y si se recorren los registros directamente conviene usar `.get()` para no depender del casing. El campo llega vacío mientras no se haya generado el PDF del comprobante.
 
 :pushpin: ***NOTA:*** Las pruebas unitarias de este servicio (`Test/test_storage.py`) requieren la variable de entorno `SDKTEST_UUID` con el UUID de un CFDI timbrado en la cuenta de pruebas, además de las ya conocidas `SDKTEST_USER`, `SDKTEST_PASSWORD` y `SDKTEST_TOKEN`.
 

--- a/README.md
+++ b/README.md
@@ -1705,6 +1705,195 @@ response = csd_obj.upload_csd("stamp", b64_csd, b64_key, password_csd)
 ```
 </details>
 
+<details>
+<summary>
+Consultar Certificados
+</summary>
+
+Método para consultar todos los certificados cargados en la cuenta.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+
+**Ejemplo de consumo de la libreria para la consulta de certificados mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.get_list_csd()
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	for certificado in response.get_data():
+		print("issuer_rfc: ", certificado["issuer_rfc"])
+		print("certificate_number: ", certificado["certificate_number"])
+		print("is_active: ", certificado["is_active"])
+		print("issuer_business_name: ", certificado["issuer_business_name"])
+		print("valid_from: ", certificado["valid_from"])
+		print("valid_to: ", certificado["valid_to"])
+		print("certificate_type: ", certificado["certificate_type"])
+```
+
+**Ejemplo de consumo de la libreria para la consulta de certificados mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.get_list_csd()
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** Si la cuenta no tiene certificados cargados, el servicio responde `status` **success** con `data` vacío; no se trata de un error.
+</details>
+
+<details>
+<summary>
+Consultar Certificado por NoCertificado
+</summary>
+
+Método para consultar un certificado en específico mediante su número de certificado.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+* Número de certificado
+
+**Ejemplo de consumo de la libreria para la consulta de un certificado mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.get_csd("30001000000400002434")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	certificado = response.get_data()
+	print("issuer_rfc: ", certificado["issuer_rfc"])
+	print("certificate_number: ", certificado["certificate_number"])
+	print("is_active: ", certificado["is_active"])
+	print("issuer_business_name: ", certificado["issuer_business_name"])
+	print("valid_from: ", certificado["valid_from"])
+	print("valid_to: ", certificado["valid_to"])
+	print("certificate_type: ", certificado["certificate_type"])
+```
+
+**Ejemplo de consumo de la libreria para la consulta de un certificado mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.get_csd("30001000000400002434")
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** A diferencia de la consulta general, aquí `data` es un objeto único, no un arreglo.
+
+:pushpin: ***NOTA:*** Si el número de certificado viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el número de certificado")` sin ejecutar la petición.
+</details>
+
+<details>
+<summary>
+Consultar Certificados por RFC
+</summary>
+
+Método para consultar los certificados de la cuenta que pertenecen a un RFC emisor.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+* RFC del emisor
+
+**Ejemplo de consumo de la libreria para la consulta de certificados por RFC mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.get_list_csd_by_rfc("EKU9003173C9")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	for certificado in response.get_data():
+		print("certificate_number: ", certificado["certificate_number"])
+		print("is_active: ", certificado["is_active"])
+		print("valid_to: ", certificado["valid_to"])
+```
+
+**Ejemplo de consumo de la libreria para la consulta de certificados por RFC mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.get_list_csd_by_rfc("EKU9003173C9")
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** Si el RFC viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el RFC")` sin ejecutar la petición.
+</details>
+
+<details>
+<summary>
+Eliminar Certificado
+</summary>
+
+Método para desactivar (eliminar) un certificado de la cuenta mediante su número de certificado.
+
+Este metodo recibe los siguientes parametros:
+* Url Servicios SW
+* Usuario y contraseña o token
+* Número de certificado
+
+**Ejemplo de consumo de la libreria para la eliminación de un certificado mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", "T2lYQ0t4L0R....ReplaceForRealToken")
+response = csd_obj.disable_csd("30001000000400002434")
+
+if response.get_status() ==  "error":
+	print(response.get_message())
+	print(response.get_messageDetail())
+else:
+	#data regresa un texto: "Certificado 30001000000400002434 desactivado."
+	print(response.get_data())
+```
+
+**Ejemplo de consumo de la libreria para la eliminación de un certificado mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Csd.Csd import Csd
+
+csd_obj = Csd("http://services.test.sw.com.mx", None, "user", "password")
+response = csd_obj.disable_csd("30001000000400002434")
+
+print(response.get_status())
+print(response.get_data())
+```
+
+:pushpin: ***NOTA:*** La operación desactiva el certificado en la cuenta. Para volver a utilizarlo es necesario cargarlo de nuevo con **Cargar Certificado**.
+
+:pushpin: ***NOTA:*** Si el número de certificado viene vacío o en `None`, la librería lanza `ValueError("Debe especificar el número de certificado")` sin ejecutar la petición.
+</details>
+
 ## TimbradoV4 ##
 Servicios de timbrado con servicios adicionales para una mejor experiencia para tu sistema, los headers pueden mezclarse o usarse al mismo tiempo.
 

--- a/Stamp/StampRequestV4.py
+++ b/Stamp/StampRequestV4.py
@@ -4,16 +4,28 @@ from Utils.response_version import ResponseVersion
 
 class StampRequestV4:
     @staticmethod
-    def stamp(url: str, token: str, xml: str, headers: dict, version: ResponseVersion):
-        """
-        Método estático para timbrar usando el servicio Timbrado v4 con soporte de versiones de respuesta.
-        """
-        path = f"/v4/cfdi33/stamp/{str(version)}"
+    def _build_headers(headers: dict, email, custom_id: str, pdf: bool) -> dict:
+        request_headers = {}
+        if email:
+            request_headers['email'] = ",".join(email) if isinstance(email, list) else email
+        if custom_id:
+            request_headers['customid'] = custom_id
+        if pdf:
+            request_headers['extra'] = "pdf"
+        if headers:
+            request_headers.update(headers)
+        return request_headers
+
+    @staticmethod
+    def stamp(url: str, token: str, xml: str, headers: dict, version: ResponseVersion,
+              email=None, custom_id: str = None, pdf: bool = False, b64: bool = False):
+        bs64 = "/b64" if b64 else ""
+        path = f"/v4/cfdi33/stamp/{str(version)}{bs64}"
         complete_url = f"{url}{path}"
         response = RequestHelper.post_v4(
             endpoint=complete_url,
             content=xml,
             token=token,
-            headers=headers
+            headers=StampRequestV4._build_headers(headers, email, custom_id, pdf)
         )
         return StampResponse(response)

--- a/Stamp/StampV4.py
+++ b/Stamp/StampV4.py
@@ -6,11 +6,16 @@ class StampV4(Services):
     def __init__(self, url, token=None, user=None, password=None):
         super(StampV4, self).__init__(url, token, user, password)
 
-    def stamp(self, xml: str, headers: dict = None, version: ResponseVersion = ResponseVersion.V1):
+    def stamp(self, xml: str, headers: dict = None, version: ResponseVersion = ResponseVersion.V1,
+              email=None, custom_id: str = None, pdf: bool = False, b64: bool = False):
         return StampRequestV4.stamp(
             url=self.get_url(),
             token=self.get_token(),
             xml=xml,
             headers=headers,
-            version=version
+            version=version,
+            email=email,
+            custom_id=custom_id,
+            pdf=pdf,
+            b64=b64
         )

--- a/Storage/Storage.py
+++ b/Storage/Storage.py
@@ -1,0 +1,14 @@
+from Storage.StorageRequest import StorageRequest
+from Utils.Services import Services
+
+class Storage(Services):
+    urlApi = None
+    def __init__(self, url, urlApi, token = None, user = None, password = None):
+        super(Storage, self).__init__(url, token, user, password)
+        if urlApi:
+            self.urlApi = urlApi
+        else:
+            print("Debe especificar la urlApi")
+
+    def get_by_uuid(self, uuid):
+        return StorageRequest.get_by_uuid(self.urlApi, self.get_token(), uuid)

--- a/Storage/StorageRequest.py
+++ b/Storage/StorageRequest.py
@@ -1,0 +1,11 @@
+from Storage.StorageResponse import StorageResponse
+from Utils.requestHelper import RequestHelper
+
+class StorageRequest:
+    @staticmethod
+    def get_by_uuid(urlApi, token, uuid):
+        """Consulta un CFDI por su UUID. El formato del UUID no se valida en local:
+        se envía tal cual y responde el servicio."""
+        endpoint = f"{urlApi}/datawarehouse/v1/live/{str(uuid)}"
+        response = RequestHelper.get_json_request(endpoint,token)
+        return StorageResponse(response)

--- a/Storage/StorageResponse.py
+++ b/Storage/StorageResponse.py
@@ -46,7 +46,7 @@ class StorageResponse(Response):
             return record.get("urlXml")
         return None
 
-    #La documentación oficial nombra el campo urlPDF y el SDK de .NET urlPdf.
+    #El servicio regresa el campo como urlPDF; se contempla urlPdf por si cambia el casing.
     def get_url_pdf(self):
         record = self.get_first_record()
         if record:

--- a/Storage/StorageResponse.py
+++ b/Storage/StorageResponse.py
@@ -1,0 +1,54 @@
+import json
+import traceback
+from Utils.response import Response
+class StorageResponse(Response):
+    def __init__(self, response):
+        try:
+            self.status_code = response.status_code
+            if(bool(response.text and response.text.strip())):
+                self.response = json.loads(response.text.encode().decode('utf8'))
+                if(self.status_code == 200):
+                    self.status = self.response["status"]
+                    self.data = self.response["data"]
+                else:
+                    if "status" in self.response:
+                        self.status = self.response["status"]
+                    self.message = self.response["message"]
+                    if "messageDetail" in self.response:
+                        self.messageDetail = self.response["messageDetail"]
+            else:
+                self.status = "error"
+                self.message = response.reason
+                self.messageDetail = response.request
+        except:
+            traceback.print_exc()
+
+    #Un UUID sin coincidencias regresa una lista vacía, no es un error.
+    def get_records(self):
+        if self.data:
+            return self.data.get("records") or []
+        return []
+
+    def get_metadata(self):
+        if self.data:
+            return self.data.get("metaData")
+        return None
+
+    def get_first_record(self):
+        records = self.get_records()
+        if records:
+            return records[0]
+        return None
+
+    def get_url_xml(self):
+        record = self.get_first_record()
+        if record:
+            return record.get("urlXml")
+        return None
+
+    #La documentación oficial nombra el campo urlPDF y el SDK de .NET urlPdf.
+    def get_url_pdf(self):
+        record = self.get_first_record()
+        if record:
+            return record.get("urlPdf") or record.get("urlPDF")
+        return None

--- a/Test/test_csd.py
+++ b/Test/test_csd.py
@@ -90,17 +90,31 @@ class TestCsd(unittest.TestCase):
         self.assertTrue("Debe especificar el RFC" == str(context.exception))
 
     #Eliminación de certificado: destructiva sobre la cuenta de pruebas.
-    #Sube el CSD de pruebas, obtiene su número y desactiva ese mismo certificado.
+    #Sube el CSD de pruebas, ubica su número y desactiva ese mismo certificado,
+    #nunca el primero de la lista, que puede pertenecer a otro RFC.
     #Para volver a habilitarlo basta con ejecutar testUploadCsd.
     @unittest.skipUnless(os.environ.get("SDKTEST_CSD_DELETE"), "Prueba destructiva, definir SDKTEST_CSD_DELETE para ejecutarla")
     def testDisableCsd(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        upload = csd_obj.upload_csd("stamp", TestCsd.open_file("Test/resources/b64CSD.txt"), TestCsd.open_file("Test/resources/b64Key.txt"), "12345678a")
+        b64_cert = TestCsd.open_file("Test/resources/b64CSD.txt")
+        upload = csd_obj.upload_csd("stamp", b64_cert, TestCsd.open_file("Test/resources/b64Key.txt"), "12345678a")
         self.assertTrue(self.expected == upload.get_status())
-        certificate_number = self.first_certificate()["certificate_number"]
+        certificate_number = self.certificate_number_of(b64_cert)
         response = csd_obj.disable_csd(certificate_number)
         self.assertTrue(self.expected == response.get_status())
         self.assertIsNotNone(response.get_data())
+        self.assertTrue(certificate_number in str(response.get_data()))
+
+    def certificate_number_of(self, b64_cert):
+        """Ubica en la cuenta el certificado cuyo Base64 coincide con el recibido.
+        upload_csd sólo regresa un texto de confirmación, sin el número de certificado."""
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd()
+        self.assertTrue(self.expected == response.get_status())
+        for certificado in response.get_data():
+            if certificado["csd_certificate"].strip() == b64_cert.strip():
+                return certificado["certificate_number"]
+        self.fail("No se encontró en la cuenta el certificado de pruebas recién cargado")
 
     def first_certificate(self):
         """Regresa el primer certificado listado en la cuenta de pruebas.

--- a/Test/test_csd.py
+++ b/Test/test_csd.py
@@ -14,7 +14,8 @@ class TestCsd(unittest.TestCase):
     url = "http://services.test.sw.com.mx"
     @staticmethod
     def open_file(pathFile):
-        out = open(pathFile, "r", encoding='ansi', errors='ignore').read()
+        with open(pathFile, "r", encoding='ansi', errors='ignore') as file:
+            out = file.read()
         return out
     
     def testUploadCsd_auth(self):
@@ -89,6 +90,49 @@ class TestCsd(unittest.TestCase):
             csd_obj.get_list_csd_by_rfc(None)
         self.assertTrue("Debe especificar el RFC" == str(context.exception))
 
+    #Paridad con .NET: GetListCsdByType y SearchActiveCsd
+    def testGetListCsdByType(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd_by_type("stamp")
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), list))
+        for certificado in response.get_data():
+            self.assertTrue("stamp" == certificado["certificate_type"])
+
+    def testGetListCsdByType_withoutResults(self):
+        #Un tipo sin certificados responde success con data vacío, no es un error.
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd_by_type("fiel")
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), list))
+
+    def testGetActiveCsd(self):
+        #El RFC y el tipo se toman de la propia cuenta, nunca se hardcodean.
+        certificado = self.first_active_certificate()
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_active_csd(certificado["issuer_rfc"], certificado["certificate_type"])
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), dict))
+        self.assertTrue(certificado["issuer_rfc"] == response.get_data()["issuer_rfc"])
+        self.assertTrue(response.get_data()["is_active"])
+
+    def testGetActiveCsd_rfcNotFound(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_active_csd("XAXX010101000", "stamp")
+        self.assertTrue("error" == response.get_status())
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacío")
+
+    def testGetListCsdByType_emptyType(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError) as context:
+            csd_obj.get_list_csd_by_type("")
+        self.assertTrue("Debe especificar el tipo de certificado" == str(context.exception))
+
+    def testGetActiveCsd_emptyType(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError):
+            csd_obj.get_active_csd("EKU9003173C9", None)
+
     #Eliminación de certificado: destructiva sobre la cuenta de pruebas.
     #Sube el CSD de pruebas, ubica su número y desactiva ese mismo certificado,
     #nunca el primero de la lista, que puede pertenecer a otro RFC.
@@ -104,6 +148,17 @@ class TestCsd(unittest.TestCase):
         self.assertTrue(self.expected == response.get_status())
         self.assertIsNotNone(response.get_data())
         self.assertTrue(certificate_number in str(response.get_data()))
+
+    def first_active_certificate(self):
+        """Regresa el primer certificado activo de la cuenta de pruebas.
+        Omite la prueba si la cuenta no tiene ninguno activo."""
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd()
+        self.assertTrue(self.expected == response.get_status())
+        for certificado in response.get_data():
+            if certificado["is_active"]:
+                return certificado
+        self.skipTest("La cuenta de pruebas no tiene certificados activos")
 
     def certificate_number_of(self, b64_cert):
         """Ubica en la cuenta el certificado cuyo Base64 coincide con el recibido.

--- a/Test/test_csd.py
+++ b/Test/test_csd.py
@@ -7,11 +7,12 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir
 sys.path.append(PROJECT_ROOT)
 
 from Csd.Csd import Csd
-from Csd.CsdResponse import CsdResponse
 
 class TestCsd(unittest.TestCase):
     expected = "success"
-    url = "http://services.test.sw.com.mx"
+    url = "https://services.test.sw.com.mx"
+    #Certificado de pruebas Test/resources/b64CSD.txt
+    noCertificado = "30001000000500003416"
     @staticmethod
     def open_file(pathFile):
         with open(pathFile, "r", encoding='ansi', errors='ignore') as file:
@@ -67,29 +68,6 @@ class TestCsd(unittest.TestCase):
         self.assertTrue("error" == response.get_status())
         self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
 
-    #UT de validación de parámetros
-    def testGetCsd_emptyCertificateNumber(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError) as context:
-            csd_obj.get_csd("")
-        self.assertTrue("Debe especificar el número de certificado" == str(context.exception))
-
-    def testGetCsd_noneCertificateNumber(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError):
-            csd_obj.get_csd(None)
-
-    def testDisableCsd_emptyCertificateNumber(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError):
-            csd_obj.disable_csd("   ")
-
-    def testGetListCsdByRfc_emptyRfc(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError) as context:
-            csd_obj.get_list_csd_by_rfc(None)
-        self.assertTrue("Debe especificar el RFC" == str(context.exception))
-
     #UT Consulta por tipo y certificado activo
     def testGetListCsdByType(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
@@ -122,26 +100,14 @@ class TestCsd(unittest.TestCase):
         self.assertTrue("error" == response.get_status())
         self.assertIsNotNone(response.get_message(), "El valor de message esta vacío")
 
-    def testGetListCsdByType_emptyType(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError) as context:
-            csd_obj.get_list_csd_by_type("")
-        self.assertTrue("Debe especificar el tipo de certificado" == str(context.exception))
-
-    def testGetActiveCsd_emptyType(self):
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        with self.assertRaises(ValueError):
-            csd_obj.get_active_csd("EKU9003173C9", None)
-
     #UT de eliminación, destructiva: desactiva el CSD de pruebas recién cargado,
     #no el primero de la lista. Para rehabilitarlo basta con ejecutar testUploadCsd.
     @unittest.skipUnless(os.environ.get("SDKTEST_CSD_DELETE"), "Prueba destructiva, definir SDKTEST_CSD_DELETE para ejecutarla")
     def testDisableCsd(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        b64_cert = TestCsd.open_file("Test/resources/b64CSD.txt")
-        upload = csd_obj.upload_csd("stamp", b64_cert, TestCsd.open_file("Test/resources/b64Key.txt"), "12345678a")
+        upload = csd_obj.upload_csd("stamp", TestCsd.open_file("Test/resources/b64CSD.txt"), TestCsd.open_file("Test/resources/b64Key.txt"), "12345678a")
         self.assertTrue(self.expected == upload.get_status())
-        certificate_number = self.certificate_number_of(b64_cert)
+        certificate_number = TestCsd.noCertificado
         response = csd_obj.disable_csd(certificate_number)
         self.assertTrue(self.expected == response.get_status())
         self.assertIsNotNone(response.get_data())
@@ -158,17 +124,6 @@ class TestCsd(unittest.TestCase):
                 return certificado
         self.skipTest("La cuenta de pruebas no tiene certificados activos")
 
-    def certificate_number_of(self, b64_cert):
-        """Ubica en la cuenta el certificado cuyo Base64 coincide con el recibido.
-        upload_csd sólo regresa un texto de confirmación, sin el número de certificado."""
-        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
-        response = csd_obj.get_list_csd()
-        self.assertTrue(self.expected == response.get_status())
-        for certificado in response.get_data():
-            if certificado["csd_certificate"].strip() == b64_cert.strip():
-                return certificado["certificate_number"]
-        self.fail("No se encontró en la cuenta el certificado de pruebas recién cargado")
-
     def first_certificate(self):
         """Regresa el primer certificado listado en la cuenta de pruebas.
         Omite la prueba si la cuenta no tiene certificados cargados."""
@@ -180,53 +135,7 @@ class TestCsd(unittest.TestCase):
             self.skipTest("La cuenta de pruebas no tiene certificados cargados")
         return data[0]
 
-class FakeResponse:
-    """Respuesta simulada de requests, para probar el parseo de CsdResponse sin red."""
-    def __init__(self, status_code, text, reason = "Bad Request"):
-        self.status_code = status_code
-        self.text = text
-        self.reason = reason
-        self.request = None
-
-class TestCsdResponse(unittest.TestCase):
-    """Pruebas del parseo de CsdResponse. No requieren credenciales ni red."""
-
-    def testParse_dataList(self):
-        body = '{"data":[{"certificate_number":"30001000000400002434","issuer_rfc":"EKU9003173C9"}],"status":"success"}'
-        response = CsdResponse(FakeResponse(200, body))
-        self.assertTrue("success" == response.get_status())
-        self.assertTrue(isinstance(response.get_data(), list))
-        self.assertTrue("30001000000400002434" == response.get_data()[0]["certificate_number"])
-
-    def testParse_dataDict(self):
-        body = '{"data":{"certificate_number":"30001000000400002434","is_active":true},"status":"success"}'
-        response = CsdResponse(FakeResponse(200, body))
-        self.assertTrue("success" == response.get_status())
-        self.assertTrue(isinstance(response.get_data(), dict))
-        self.assertTrue("30001000000400002434" == response.get_data()["certificate_number"])
-
-    def testParse_dataString(self):
-        body = '{"data":"Certificado 30001000000400002434 desactivado.","status":"success"}'
-        response = CsdResponse(FakeResponse(200, body))
-        self.assertTrue("success" == response.get_status())
-        self.assertTrue("Certificado 30001000000400002434 desactivado." == response.get_data())
-
-    def testParse_error(self):
-        #Regresión: antes status quedaba en None en la rama de error.
-        body = '{"message":"Certificado no encontrado","messageDetail":"Detalle del error","data":null,"status":"error"}'
-        response = CsdResponse(FakeResponse(400, body))
-        self.assertTrue("error" == response.get_status())
-        self.assertTrue("Certificado no encontrado" == response.get_message())
-        self.assertTrue("Detalle del error" == response.get_messageDetail())
-
-    def testParse_emptyBody(self):
-        response = CsdResponse(FakeResponse(500, "", "Internal Server Error"))
-        self.assertTrue("error" == response.get_status())
-        self.assertTrue("Internal Server Error" == response.get_message())
-
 if __name__ == '__main__':
-    loader = unittest.TestLoader()
-    suite = unittest.TestSuite([loader.loadTestsFromTestCase(TestCsd),
-                                loader.loadTestsFromTestCase(TestCsdResponse)])
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestCsd)
     result = unittest.TextTestRunner(verbosity=2).run(suite)
     sys.exit(not result.wasSuccessful())

--- a/Test/test_csd.py
+++ b/Test/test_csd.py
@@ -7,9 +7,11 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir
 sys.path.append(PROJECT_ROOT)
 
 from Csd.Csd import Csd
+from Csd.CsdResponse import CsdResponse
 
 class TestCsd(unittest.TestCase):
     expected = "success"
+    url = "http://services.test.sw.com.mx"
     @staticmethod
     def open_file(pathFile):
         out = open(pathFile, "r", encoding='ansi', errors='ignore').read()
@@ -25,5 +27,139 @@ class TestCsd(unittest.TestCase):
         response = csd_obj.upload_csd("stamp", TestCsd.open_file("Test/resources/b64CSD.txt"), TestCsd.open_file("Test/resources/b64Key.txt"),"12345678a")
         self.assertTrue(self.expected == response.get_status())
 
-suite = unittest.TestLoader().loadTestsFromTestCase(TestCsd)
-unittest.TextTestRunner(verbosity=2).run(suite)
+    #Consulta de certificados
+    def testGetListCsd(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd()
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), list))
+
+    def testGetListCsd_auth(self):
+        csd_obj = Csd(TestCsd.url, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        response = csd_obj.get_list_csd()
+        self.assertTrue(self.expected == response.get_status())
+
+    def testGetCsd(self):
+        #El número de certificado se toma de la propia cuenta, nunca se hardcodea.
+        certificate_number = self.first_certificate()["certificate_number"]
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_csd(certificate_number)
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(certificate_number == response.get_data()["certificate_number"])
+
+    def testGetCsd_notFound(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_csd("00000000000000000000")
+        self.assertTrue("error" == response.get_status())
+        self.assertIsNotNone(response.get_messageDetail(), "El valor de messageDetail esta vacio")
+
+    def testGetListCsdByRfc(self):
+        rfc = self.first_certificate()["issuer_rfc"]
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd_by_rfc(rfc)
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), list))
+
+    def testGetListCsd_invalidToken(self):
+        csd_obj = Csd(TestCsd.url, "T2lYQ0t4.....")
+        response = csd_obj.get_list_csd()
+        self.assertTrue("error" == response.get_status())
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+
+    #Validación de parámetros: falla antes de ejecutar la petición
+    def testGetCsd_emptyCertificateNumber(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError) as context:
+            csd_obj.get_csd("")
+        self.assertTrue("Debe especificar el número de certificado" == str(context.exception))
+
+    def testGetCsd_noneCertificateNumber(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError):
+            csd_obj.get_csd(None)
+
+    def testDisableCsd_emptyCertificateNumber(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError):
+            csd_obj.disable_csd("   ")
+
+    def testGetListCsdByRfc_emptyRfc(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(ValueError) as context:
+            csd_obj.get_list_csd_by_rfc(None)
+        self.assertTrue("Debe especificar el RFC" == str(context.exception))
+
+    #Eliminación de certificado: destructiva sobre la cuenta de pruebas.
+    #Sube el CSD de pruebas, obtiene su número y desactiva ese mismo certificado.
+    #Para volver a habilitarlo basta con ejecutar testUploadCsd.
+    @unittest.skipUnless(os.environ.get("SDKTEST_CSD_DELETE"), "Prueba destructiva, definir SDKTEST_CSD_DELETE para ejecutarla")
+    def testDisableCsd(self):
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        upload = csd_obj.upload_csd("stamp", TestCsd.open_file("Test/resources/b64CSD.txt"), TestCsd.open_file("Test/resources/b64Key.txt"), "12345678a")
+        self.assertTrue(self.expected == upload.get_status())
+        certificate_number = self.first_certificate()["certificate_number"]
+        response = csd_obj.disable_csd(certificate_number)
+        self.assertTrue(self.expected == response.get_status())
+        self.assertIsNotNone(response.get_data())
+
+    def first_certificate(self):
+        """Regresa el primer certificado listado en la cuenta de pruebas.
+        Omite la prueba si la cuenta no tiene certificados cargados."""
+        csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
+        response = csd_obj.get_list_csd()
+        self.assertTrue(self.expected == response.get_status())
+        data = response.get_data()
+        if not data:
+            self.skipTest("La cuenta de pruebas no tiene certificados cargados")
+        return data[0]
+
+class FakeResponse:
+    """Respuesta simulada de requests, para probar el parseo de CsdResponse sin red."""
+    def __init__(self, status_code, text, reason = "Bad Request"):
+        self.status_code = status_code
+        self.text = text
+        self.reason = reason
+        self.request = None
+
+class TestCsdResponse(unittest.TestCase):
+    """Pruebas del parseo de CsdResponse. No requieren credenciales ni red."""
+
+    def testParse_dataList(self):
+        body = '{"data":[{"certificate_number":"30001000000400002434","issuer_rfc":"EKU9003173C9"}],"status":"success"}'
+        response = CsdResponse(FakeResponse(200, body))
+        self.assertTrue("success" == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), list))
+        self.assertTrue("30001000000400002434" == response.get_data()[0]["certificate_number"])
+
+    def testParse_dataDict(self):
+        body = '{"data":{"certificate_number":"30001000000400002434","is_active":true},"status":"success"}'
+        response = CsdResponse(FakeResponse(200, body))
+        self.assertTrue("success" == response.get_status())
+        self.assertTrue(isinstance(response.get_data(), dict))
+        self.assertTrue("30001000000400002434" == response.get_data()["certificate_number"])
+
+    def testParse_dataString(self):
+        body = '{"data":"Certificado 30001000000400002434 desactivado.","status":"success"}'
+        response = CsdResponse(FakeResponse(200, body))
+        self.assertTrue("success" == response.get_status())
+        self.assertTrue("Certificado 30001000000400002434 desactivado." == response.get_data())
+
+    def testParse_error(self):
+        #Regresión: antes de esta versión status quedaba en None en la rama de error.
+        body = '{"message":"Certificado no encontrado","messageDetail":"Detalle del error","data":null,"status":"error"}'
+        response = CsdResponse(FakeResponse(400, body))
+        self.assertTrue("error" == response.get_status())
+        self.assertTrue("Certificado no encontrado" == response.get_message())
+        self.assertTrue("Detalle del error" == response.get_messageDetail())
+
+    def testParse_emptyBody(self):
+        response = CsdResponse(FakeResponse(500, "", "Internal Server Error"))
+        self.assertTrue("error" == response.get_status())
+        self.assertTrue("Internal Server Error" == response.get_message())
+
+if __name__ == '__main__':
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite([loader.loadTestsFromTestCase(TestCsd),
+                                loader.loadTestsFromTestCase(TestCsdResponse)])
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/Test/test_csd.py
+++ b/Test/test_csd.py
@@ -28,7 +28,7 @@ class TestCsd(unittest.TestCase):
         response = csd_obj.upload_csd("stamp", TestCsd.open_file("Test/resources/b64CSD.txt"), TestCsd.open_file("Test/resources/b64Key.txt"),"12345678a")
         self.assertTrue(self.expected == response.get_status())
 
-    #Consulta de certificados
+    #UT Consulta de certificados
     def testGetListCsd(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
         response = csd_obj.get_list_csd()
@@ -67,7 +67,7 @@ class TestCsd(unittest.TestCase):
         self.assertTrue("error" == response.get_status())
         self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
 
-    #Validación de parámetros: falla antes de ejecutar la petición
+    #UT de validación de parámetros
     def testGetCsd_emptyCertificateNumber(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
         with self.assertRaises(ValueError) as context:
@@ -90,7 +90,7 @@ class TestCsd(unittest.TestCase):
             csd_obj.get_list_csd_by_rfc(None)
         self.assertTrue("Debe especificar el RFC" == str(context.exception))
 
-    #Paridad con .NET: GetListCsdByType y SearchActiveCsd
+    #UT Consulta por tipo y certificado activo
     def testGetListCsdByType(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
         response = csd_obj.get_list_csd_by_type("stamp")
@@ -133,10 +133,8 @@ class TestCsd(unittest.TestCase):
         with self.assertRaises(ValueError):
             csd_obj.get_active_csd("EKU9003173C9", None)
 
-    #Eliminación de certificado: destructiva sobre la cuenta de pruebas.
-    #Sube el CSD de pruebas, ubica su número y desactiva ese mismo certificado,
-    #nunca el primero de la lista, que puede pertenecer a otro RFC.
-    #Para volver a habilitarlo basta con ejecutar testUploadCsd.
+    #UT de eliminación, destructiva: desactiva el CSD de pruebas recién cargado,
+    #no el primero de la lista. Para rehabilitarlo basta con ejecutar testUploadCsd.
     @unittest.skipUnless(os.environ.get("SDKTEST_CSD_DELETE"), "Prueba destructiva, definir SDKTEST_CSD_DELETE para ejecutarla")
     def testDisableCsd(self):
         csd_obj = Csd(TestCsd.url, os.environ["SDKTEST_TOKEN"])
@@ -214,7 +212,7 @@ class TestCsdResponse(unittest.TestCase):
         self.assertTrue("Certificado 30001000000400002434 desactivado." == response.get_data())
 
     def testParse_error(self):
-        #Regresión: antes de esta versión status quedaba en None en la rama de error.
+        #Regresión: antes status quedaba en None en la rama de error.
         body = '{"message":"Certificado no encontrado","messageDetail":"Detalle del error","data":null,"status":"error"}'
         response = CsdResponse(FakeResponse(400, body))
         self.assertTrue("error" == response.get_status())

--- a/Test/test_pdf.py
+++ b/Test/test_pdf.py
@@ -1,6 +1,8 @@
 import unittest
-import os 
+import os
 import sys
+import time
+import uuid
 from base64 import b64decode
 
 #Función para poder importar módulos necesarios.
@@ -10,11 +12,23 @@ sys.path.append(PROJECT_ROOT)
 from Pdf.Pdf import Pdf
 
 class TestPdf(unittest.TestCase):
+    url = "https://services.test.sw.com.mx"
+    urlApi = "https://api.test.sw.com.mx"
+    #SDKTEST_UUID: UUID de un CFDI timbrado en la cuenta de pruebas, nunca de un cliente real.
+    uuidNotFound = "00000000-0000-0000-0000-000000000000"
+    uuidInvalid = "no-es-uuid"
+
     @staticmethod
     def open_file(pathFile):
         out = open(pathFile,"r", encoding='latin_1', errors='ignore').read()
         return out
     
+    @staticmethod
+    def esperar_limite():
+        #La regeneración limita el número de peticiones por usuario y responde 429 si se
+        #consumen seguidas: se espacian para no depender del ritmo de la suite.
+        time.sleep(3)
+
     @staticmethod
     def save_pdf(contentB64):
         bytes = b64decode(contentB64, validate=True)
@@ -90,5 +104,72 @@ class TestPdf(unittest.TestCase):
             print (Key,"=",Value)
         TestPdf.save_pdf(response.data['contentB64'])
 
-suite = unittest.TestLoader().loadTestsFromTestCase(TestPdf)
-unittest.TextTestRunner(verbosity=2).run(suite)
+    #UT Regeneración de PDF
+    def test_regenerate_pdf_token(self):
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        self.assertTrue(response.get_status() == "success")
+        self.assertTrue(200 == response.get_status_code())
+        self.assertIn("correctamente", response.get_message())
+
+    def test_regenerate_pdf_auth(self):
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
+        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        self.assertTrue(response.get_status() == "success")
+
+    def test_regenerate_pdf_uuidObject(self):
+        #El UUID también se acepta como uuid.UUID, no sólo como cadena.
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf(uuid.UUID(os.environ['SDKTEST_UUID']))
+        self.assertTrue(response.get_status() == "success")
+
+    def test_regenerate_pdf_template_extras(self):
+        #Los datos extra viajan anidados en extras, igual que en la generación de PDF.
+        extras = {
+            'REFERENCIA': "Referencia de pruebas"
+        }
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'], None, "cfdi40", extras)
+        self.assertTrue(response.get_status() == "success")
+
+    #UT de Error
+    def test_regenerate_pdf_notFound(self):
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf(TestPdf.uuidNotFound)
+        self.assertTrue(response.get_status() == "error")
+        self.assertTrue(404 == response.get_status_code())
+        self.assertIn("UUID", response.get_message())
+
+    def test_regenerate_pdf_invalidFormat(self):
+        #Un UUID mal formado responde igual que uno inexistente: 404 con el mensaje del
+        #servicio. El formato no se valida en local.
+        TestPdf.esperar_limite()
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf(TestPdf.uuidInvalid)
+        self.assertTrue(response.get_status() == "error")
+        self.assertTrue(404 == response.get_status_code())
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+
+    def test_regenerate_pdf_emptyString(self):
+        #Una cadena vacía deja la ruta en /pdf/v1/api/RegeneratePdf/, que no existe: responde
+        #404 y no un recurso distinto al pedido, así que el valor se envía tal cual.
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
+        response = pdf.regenerate_pdf("")
+        self.assertTrue(response.get_status() == "error")
+        self.assertTrue(404 == response.get_status_code())
+
+    def test_regenerate_pdf_invalidToken(self):
+        pdf = Pdf(TestPdf.url, TestPdf.urlApi, "T2lYQ0t4.....")
+        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        self.assertTrue(response.get_status() == "error")
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestPdf)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/Test/test_pdf.py
+++ b/Test/test_pdf.py
@@ -14,6 +14,7 @@ from Pdf.Pdf import Pdf
 class TestPdf(unittest.TestCase):
     url = "https://services.test.sw.com.mx"
     urlApi = "https://api.test.sw.com.mx"
+    uuidTest = "3001449c-ef91-4bd5-a698-687bdea46414"
     uuidNotFound = "00000000-0000-0000-0000-000000000000"
     uuidInvalid = "no-es-uuid"
 
@@ -106,7 +107,7 @@ class TestPdf(unittest.TestCase):
     def test_regenerate_pdf_token(self):
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
-        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        response = pdf.regenerate_pdf(TestPdf.uuidTest)
         self.assertTrue(response.get_status() == "success")
         self.assertTrue(200 == response.get_status_code())
         self.assertIn("correctamente", response.get_message())
@@ -114,13 +115,13 @@ class TestPdf(unittest.TestCase):
     def test_regenerate_pdf_auth(self):
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        response = pdf.regenerate_pdf(TestPdf.uuidTest)
         self.assertTrue(response.get_status() == "success")
 
     def test_regenerate_pdf_uuidObject(self):
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
-        response = pdf.regenerate_pdf(uuid.UUID(os.environ['SDKTEST_UUID']))
+        response = pdf.regenerate_pdf(uuid.UUID(TestPdf.uuidTest))
         self.assertTrue(response.get_status() == "success")
 
     def test_regenerate_pdf_template_extras(self):
@@ -129,7 +130,7 @@ class TestPdf(unittest.TestCase):
         }
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
-        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'], None, "cfdi40", extras)
+        response = pdf.regenerate_pdf(TestPdf.uuidTest, None, "cfdi40", extras)
         self.assertTrue(response.get_status() == "success")
 
     #UT de Error
@@ -157,7 +158,7 @@ class TestPdf(unittest.TestCase):
 
     def test_regenerate_pdf_invalidToken(self):
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, "T2lYQ0t4.....")
-        response = pdf.regenerate_pdf(os.environ['SDKTEST_UUID'])
+        response = pdf.regenerate_pdf(TestPdf.uuidTest)
         self.assertTrue(response.get_status() == "error")
         self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
 

--- a/Test/test_pdf.py
+++ b/Test/test_pdf.py
@@ -14,7 +14,6 @@ from Pdf.Pdf import Pdf
 class TestPdf(unittest.TestCase):
     url = "https://services.test.sw.com.mx"
     urlApi = "https://api.test.sw.com.mx"
-    #SDKTEST_UUID: UUID de un CFDI timbrado en la cuenta de pruebas, nunca de un cliente real.
     uuidNotFound = "00000000-0000-0000-0000-000000000000"
     uuidInvalid = "no-es-uuid"
 
@@ -25,8 +24,7 @@ class TestPdf(unittest.TestCase):
     
     @staticmethod
     def esperar_limite():
-        #La regeneración limita el número de peticiones por usuario y responde 429 si se
-        #consumen seguidas: se espacian para no depender del ritmo de la suite.
+        #La regeneración responde 429 cuando se consumen varias peticiones seguidas.
         time.sleep(3)
 
     @staticmethod
@@ -120,14 +118,12 @@ class TestPdf(unittest.TestCase):
         self.assertTrue(response.get_status() == "success")
 
     def test_regenerate_pdf_uuidObject(self):
-        #El UUID también se acepta como uuid.UUID, no sólo como cadena.
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
         response = pdf.regenerate_pdf(uuid.UUID(os.environ['SDKTEST_UUID']))
         self.assertTrue(response.get_status() == "success")
 
     def test_regenerate_pdf_template_extras(self):
-        #Los datos extra viajan anidados en extras, igual que en la generación de PDF.
         extras = {
             'REFERENCIA': "Referencia de pruebas"
         }
@@ -146,8 +142,6 @@ class TestPdf(unittest.TestCase):
         self.assertIn("UUID", response.get_message())
 
     def test_regenerate_pdf_invalidFormat(self):
-        #Un UUID mal formado responde igual que uno inexistente: 404 con el mensaje del
-        #servicio. El formato no se valida en local.
         TestPdf.esperar_limite()
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
         response = pdf.regenerate_pdf(TestPdf.uuidInvalid)
@@ -156,8 +150,6 @@ class TestPdf(unittest.TestCase):
         self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
 
     def test_regenerate_pdf_emptyString(self):
-        #Una cadena vacía deja la ruta en /pdf/v1/api/RegeneratePdf/, que no existe: responde
-        #404 y no un recurso distinto al pedido, así que el valor se envía tal cual.
         pdf = Pdf(TestPdf.url, TestPdf.urlApi, os.environ['SDKTEST_TOKEN'])
         response = pdf.regenerate_pdf("")
         self.assertTrue(response.get_status() == "error")

--- a/Test/test_storage.py
+++ b/Test/test_storage.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import sys
+import uuid
 import requests
 
 #Función para poder importar módulos necesarios.
@@ -22,7 +23,15 @@ class TestStorage(unittest.TestCase):
         response = storage_obj.get_by_uuid(os.environ["SDKTEST_UUID"])
         self.assertTrue(self.expected == response.get_status())
         self.assertTrue(len(response.get_records()) > 0)
+        self.assertTrue(os.environ["SDKTEST_UUID"] == response.get_first_record()["uuid"])
         self.assertIsNotNone(response.get_url_xml(), "El valor de urlXml esta vacio")
+
+    def test_get_by_uuid_uuidObject(self):
+        #El UUID también se acepta como uuid.UUID, no sólo como cadena.
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = storage_obj.get_by_uuid(uuid.UUID(os.environ["SDKTEST_UUID"]))
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(os.environ["SDKTEST_UUID"] == response.get_first_record()["uuid"])
 
     def test_get_by_uuid_auth(self):
         storage_obj = Storage(TestStorage.url, TestStorage.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])

--- a/Test/test_storage.py
+++ b/Test/test_storage.py
@@ -18,6 +18,7 @@ class TestStorage(unittest.TestCase):
     uuidNotFound = "00000000-0000-0000-0000-000000000000"
     uuidInvalid = "no-es-uuid"
 
+    #UT Recuperación de XML por UUID
     def test_get_by_uuid(self):
         storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
         response = storage_obj.get_by_uuid(os.environ["SDKTEST_UUID"])
@@ -38,6 +39,7 @@ class TestStorage(unittest.TestCase):
         response = storage_obj.get_by_uuid(os.environ["SDKTEST_UUID"])
         self.assertTrue(self.expected == response.get_status())
 
+    #UT Consultas sin coincidencias
     def test_get_by_uuid_notFound(self):
         #Un UUID inexistente responde success con records vacío, no es un error.
         storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
@@ -55,6 +57,7 @@ class TestStorage(unittest.TestCase):
         self.assertTrue(self.expected == response.get_status())
         self.assertTrue(len(response.get_records()) == 0)
 
+    #UT de Error
     def test_get_by_uuid_emptyString(self):
         #Una cadena vacía deja la ruta en /datawarehouse/v1/live/, que es el buscador por
         #fechas: responde 400 pidiendo la fecha de inicio. No regresa un recurso distinto

--- a/Test/test_storage.py
+++ b/Test/test_storage.py
@@ -38,17 +38,23 @@ class TestStorage(unittest.TestCase):
         self.assertIsNone(response.get_url_xml())
 
     def test_get_by_uuid_invalidFormat(self):
-        #PENDIENTE DE VERIFICAR CONTRA EL AMBIENTE: no se pudo ejecutar la consulta con un
-        #UUID mal formado, así que se afirma únicamente el contrato común a las dos respuestas
-        #posibles (400 con message, o 200 con records vacío). Al correrla se fija la aserción exacta.
+        #Un UUID mal formado responde igual que uno inexistente: 200 success con records
+        #vacío y sin message. El servicio no valida el formato.
         storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
         response = storage_obj.get_by_uuid(TestStorage.uuidInvalid)
-        self.assertIsNotNone(response.get_status_code())
-        self.assertIn(response.get_status(), ("success", "error"))
-        if response.get_status() == "error":
-            self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
-        else:
-            self.assertTrue(len(response.get_records()) == 0)
+        self.assertTrue(200 == response.get_status_code())
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(len(response.get_records()) == 0)
+
+    def test_get_by_uuid_emptyString(self):
+        #Una cadena vacía deja la ruta en /datawarehouse/v1/live/, que es el buscador por
+        #fechas: responde 400 pidiendo la fecha de inicio. No regresa un recurso distinto
+        #al pedido, así que el valor se envía tal cual y responde el servicio.
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = storage_obj.get_by_uuid("")
+        self.assertTrue("error" == response.get_status())
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+        self.assertTrue(len(response.get_records()) == 0)
 
     def test_get_by_uuid_invalidToken(self):
         storage_obj = Storage(TestStorage.url, TestStorage.urlApi, "T2lYQ0t4.....")

--- a/Test/test_storage.py
+++ b/Test/test_storage.py
@@ -1,0 +1,69 @@
+import unittest
+import os
+import sys
+import requests
+
+#Función para poder importar módulos necesarios.
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+sys.path.append(PROJECT_ROOT)
+
+from Storage.Storage import Storage
+
+class TestStorage(unittest.TestCase):
+    expected = "success"
+    url = "https://services.test.sw.com.mx"
+    urlApi = "https://api.test.sw.com.mx"
+    #SDKTEST_UUID: UUID de un CFDI timbrado en la cuenta de pruebas, nunca de un cliente real.
+    uuidNotFound = "00000000-0000-0000-0000-000000000000"
+    uuidInvalid = "no-es-uuid"
+
+    def test_get_by_uuid(self):
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = storage_obj.get_by_uuid(os.environ["SDKTEST_UUID"])
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(len(response.get_records()) > 0)
+        self.assertIsNotNone(response.get_url_xml(), "El valor de urlXml esta vacio")
+
+    def test_get_by_uuid_auth(self):
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        response = storage_obj.get_by_uuid(os.environ["SDKTEST_UUID"])
+        self.assertTrue(self.expected == response.get_status())
+
+    def test_get_by_uuid_notFound(self):
+        #Un UUID inexistente responde success con records vacío, no es un error.
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = storage_obj.get_by_uuid(TestStorage.uuidNotFound)
+        self.assertTrue(self.expected == response.get_status())
+        self.assertTrue(len(response.get_records()) == 0)
+        self.assertIsNone(response.get_url_xml())
+
+    def test_get_by_uuid_invalidFormat(self):
+        #PENDIENTE DE VERIFICAR CONTRA EL AMBIENTE: no se pudo ejecutar la consulta con un
+        #UUID mal formado, así que se afirma únicamente el contrato común a las dos respuestas
+        #posibles (400 con message, o 200 con records vacío). Al correrla se fija la aserción exacta.
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = storage_obj.get_by_uuid(TestStorage.uuidInvalid)
+        self.assertIsNotNone(response.get_status_code())
+        self.assertIn(response.get_status(), ("success", "error"))
+        if response.get_status() == "error":
+            self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+        else:
+            self.assertTrue(len(response.get_records()) == 0)
+
+    def test_get_by_uuid_invalidToken(self):
+        storage_obj = Storage(TestStorage.url, TestStorage.urlApi, "T2lYQ0t4.....")
+        response = storage_obj.get_by_uuid(TestStorage.uuidNotFound)
+        self.assertTrue("error" == response.get_status())
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+
+    def test_get_by_uuid_withoutUrlApi(self):
+        #Con urlApi vacía la librería avisa por consola igual que Pdf y AccountUser, y la
+        #petición no se puede armar. Se documenta el comportamiento actual del repositorio.
+        storage_obj = Storage(TestStorage.url, "", os.environ["SDKTEST_TOKEN"])
+        with self.assertRaises(requests.exceptions.RequestException):
+            storage_obj.get_by_uuid(TestStorage.uuidNotFound)
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestStorage)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/Test/test_v4_services.py
+++ b/Test/test_v4_services.py
@@ -64,7 +64,7 @@ class TestV4Basic(unittest.TestCase):
         data["Fecha"] = new_date
         return json.dumps(data, indent=2, ensure_ascii=False)
 
-    def esperar_url_pdf(self, uuid):
+    def wait_url_pdf(self, uuid):
         #El PDF del comprobante tarda en quedar disponible en el ADT.
         storage = Storage(self.url, self.urlApi, self.token)
         for _ in range(12):
@@ -90,7 +90,7 @@ class TestV4Basic(unittest.TestCase):
         self.assertIsNotNone(response.data)
         self.assertIsNotNone(response.data.get("cfdi"))
         self.assertIsNotNone(response.data.get("uuid"))
-        self.assertIsNotNone(self.esperar_url_pdf(response.data.get("uuid")),
+        self.assertIsNotNone(self.wait_url_pdf(response.data.get("uuid")),
                              "El comprobante se timbró sin generar el PDF en el ADT")
 
     def test_issue_xml_token_minimal_headers(self):
@@ -106,7 +106,6 @@ class TestV4Basic(unittest.TestCase):
         self.assertIsNotNone(response.data.get("cfdi"))
 
     def test_issue_xml_headers_dict(self):
-        #El diccionario headers se conserva y sus valores prevalecen sobre los parámetros.
         issue = IssueV4(self.url, self.token)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
         headers = {
@@ -144,7 +143,6 @@ class TestV4Basic(unittest.TestCase):
                                pdf=True,
                                version=ResponseVersion.V2)
 
-        #El comprobante de pruebas ya está timbrado: el servicio responde con el timbre previo.
         if response.get_status() == "error":
             self.assertIn("307", response.get_message())
         else:
@@ -224,7 +222,7 @@ class TestV4Basic(unittest.TestCase):
         self.assertEqual(200, response.status_code)
         self.assertIsNotNone(response.data)
         self.assertIsNotNone(response.data.get("uuid"))
-        self.assertIsNotNone(self.esperar_url_pdf(response.data.get("uuid")),
+        self.assertIsNotNone(self.wait_url_pdf(response.data.get("uuid")),
                              "El comprobante se timbró sin generar el PDF en el ADT")
 
     #UT de Error

--- a/Test/test_v4_services.py
+++ b/Test/test_v4_services.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import sys
 import json
+from base64 import b64encode
 from datetime import datetime, timedelta
 import xml.etree.ElementTree as ET
 from io import BytesIO
@@ -9,350 +10,297 @@ from pathlib import Path
 import random
 import string
 import time
-from typing import Union
 
 PROJECT_ROOT = str(Path(__file__).parent.parent.absolute())
 sys.path.insert(0, PROJECT_ROOT)
 
 from Issue.IssueV4 import IssueV4
 from Stamp.StampV4 import StampV4
+from Storage.Storage import Storage
 from Utils.response_version import ResponseVersion
 
 class TestV4Basic(unittest.TestCase):
-    """
-    Pruebas básicas para los servicios V4 de CFDI.
-    Se prueban escenarios de éxito y error para Issue y Stamp.
-    """
-    
+
     def setUp(self):
-        """Configuración inicial para todas las pruebas"""
-        self.url = "http://services.test.sw.com.mx"
+        self.url = "https://services.test.sw.com.mx"
+        self.urlApi = "https://api.test.sw.com.mx"
         self.user = os.environ.get("SDKTEST_USER")
         self.password = os.environ.get("SDKTEST_PASSWORD")
         self.token = os.environ.get("SDKTEST_TOKEN")
-        
+
         if not all([self.user, self.password, self.token]):
             raise ValueError("Faltan variables de entorno necesarias: SDKTEST_USER, SDKTEST_PASSWORD, SDKTEST_TOKEN")
-    
+
     @staticmethod
     def generate_custom_id(prefix):
-        """Genera un customId único usando un prefijo y caracteres aleatorios"""
-        # Genera 4 caracteres aleatorios (2 letras y 2 números)
         letters = ''.join(random.choices(string.ascii_uppercase, k=2))
         numbers = ''.join(random.choices(string.digits, k=2))
         timestamp = datetime.now().strftime("%H%M")
         return f"{prefix}-{letters}{numbers}-{timestamp}"
-    
+
     @staticmethod
     def update_date_xml(path_xml):
-        """Actualiza la fecha en un archivo XML a la hora actual menos 1 hora"""
-        try:
-            ns = {"cfdi": "http://www.sat.gob.mx/cfd/4"}
-            tree = ET.parse(path_xml)
-            root = tree.getroot()
-            
-            new_date = datetime.now() - timedelta(hours=1)
-            if "Fecha" in root.attrib:
-                root.set("Fecha", new_date.strftime("%Y-%m-%dT%H:%M:%S"))
-                ET.register_namespace("cfdi", ns["cfdi"]) 
-                xml_buffer = BytesIO()
-                tree.write(xml_buffer, encoding="utf-8", xml_declaration=True)
-                return xml_buffer.getvalue().decode("utf-8")
-            else:
-                raise ValueError("No se encontró el atributo 'Fecha' en el XML")
-        except Exception as e:
-            raise
+        ns = {"cfdi": "http://www.sat.gob.mx/cfd/4"}
+        tree = ET.parse(path_xml)
+        root = tree.getroot()
 
-    # ============= CASOS DE ÉXITO =============
-
-    def test_issue_xml_auth_all_headers(self):
-        """Escenario 1: Issue XML exitoso con autenticación por credenciales y todos los headers"""
-        try:
-            issue = IssueV4(self.url, None, self.user, self.password)
-            xml_content = self.update_date_xml("Test/resources/xml40.xml")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISS"),
-                "email": "test1@test.com,test2@test.com",
-                "pdf": "true"
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("success", response.get_status())
-            self.assertIsNotNone(response.data)
-            self.assertIsNotNone(response.data.get("cfdi")) #Dato de version 4
-            self.assertIsNotNone(response.data.get("uuid")) #Dato de version 4 - UUID del comprobante
-            self.assertEqual(200, response.status_code)
-        except Exception as e:
-            raise
-
-    def test_issue_xml_token_minimal_headers(self):
-        """Escenario 2: Issue XML exitoso con token y solo customId"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            xml_content = self.update_date_xml("Test/resources/xml40.xml")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISS")
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V3)
-            
-            self.assertEqual("success", response.get_status())
-            self.assertEqual(200, response.status_code)
-            self.assertIsNotNone(response.data.get("cfdi")) #Dato de version 3
-        except Exception as e:
-            raise
-
-    def test_stamp_token_all_headers(self):
-        """Escenario 3: Stamp exitoso con token y todos los headers"""
-        try:
-            stamp = StampV4(self.url, self.token)
-            xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
-            
-            headers = {
-                "customid": self.generate_custom_id("STP"),
-                "email": "stamp1@test.com,stamp2@test.com",
-                "pdf": "true"
-            }
-            
-            response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
-            
-            if response.get_status() == "error":
-                self.assertIn("307", response.get_message())
-                self.assertIn("timbre previo", response.get_message().lower())
-            else:
-                self.assertEqual("success", response.get_status())
-                self.assertEqual(200, response.status_code)
-                self.assertIsNotNone(response.data.get("tfd")) #Dato de version 2
-        except Exception as e:
-            raise
-
-    def test_stamp_auth_email_only(self):
-        """Escenario 4: Stamp exitoso con credenciales y solo email"""
-        try:
-            stamp = StampV4(self.url, None, self.user, self.password)
-            xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
-            
-            headers = {
-                "email": "stamp1@test.com"
-            }
-            
-            response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            if response.get_status() == "error":
-                self.assertIn("307", response.get_message())
-                self.assertIn("timbre previo", response.get_message().lower())
-            else:
-                self.assertEqual("success", response.get_status())
-                self.assertEqual(200, response.status_code)
-        except Exception as e:
-            raise
-
-    def test_issue_json_auth_all_headers(self):
-        """Escenario 5: Issue JSON exitoso con autenticación y todos los headers"""
-        try:
-            issue = IssueV4(self.url, None, self.user, self.password)
-            json_content = self.update_date_json("Test/resources/cfdi.json")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISJ"),
-                "email": "test1@test.com,test2@test.com",
-                "pdf": "true"
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("success", response.get_status())
-            self.assertIsNotNone(response.data)
-            self.assertIsNotNone(response.data.get("cfdi")) #Dato de version 4
-            self.assertIsNotNone(response.data.get("uuid")) #Dato de version 4 - UUID del comprobante
-            self.assertEqual(200, response.status_code)
-        except Exception as e:
-            raise
-
-    def test_issue_json_token_minimal_headers(self):
-        """Escenario 6: Issue JSON exitoso con token y solo customId usando V3"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            time.sleep(5)
-            json_content = self.update_date_json("Test/resources/cfdi.json")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISJ")
-            }
-           
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V3)
-            
-            self.assertEqual("success", response.get_status())
-            self.assertEqual(200, response.status_code)
-            self.assertIsNotNone(response.data.get("cfdi")) #Dato de version 3
-        except Exception as e:
-            raise
-
-    def test_issue_json_with_pdf(self):
-        """Escenario 7: Issue JSON exitoso validando respuesta con PDF"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            time.sleep(5)
-            json_content = self.update_date_json("Test/resources/cfdi.json")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISJ"),
-                "pdf": "true",
-                "email": "test1@test.com"
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("success", response.get_status())
-            self.assertEqual(200, response.status_code)
-            self.assertIsNotNone(response.data)
-            self.assertIsNotNone(response.data.get("cfdi")) #Dato de version 4
-            self.assertIsNotNone(response.data.get("uuid")) #Dato de version 4 - UUID del comprobante
-        except Exception as e:
-            raise
-
-    # ============= CASOS DE ERROR =============
-
-    def test_issue_xml_invalid_credentials(self):
-        """Error 1: Issue XML con credenciales inválidas"""
-        try:
-            issue = IssueV4(self.url, None, "usuario_invalido", "pass_invalido")
-            xml_content = self.update_date_xml("Test/resources/xml40.xml")
-            
-            headers = {
-                "customid": self.generate_custom_id("ISS")
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response.get_status())
-            self.assertNotEqual(200, response.status_code)
-            self.assertIsNone(response.data)
-            self.assertEqual("AU4101 - El token proporcionado viene vacio.", response.get_message())
-        except Exception as e:
-            raise
-
-    def test_issue_xml_invalid_xml(self):
-        """Error 2: Issue XML con XML mal formado o sin certificado"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            xml_content = "<xml>mal formado</xml>"
-            
-            headers = {
-                "customid": self.generate_custom_id("ISS")
-            }
-            
-            response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response.get_status())
-            self.assertNotEqual(200, response.status_code)
-            self.assertIsNotNone(response.get_message)
-        except Exception as e:
-            raise
-
-    def test_stamp_invalid_token(self):
-        """Error 3: Stamp con token inválido"""
-        try:
-            stamp = StampV4(self.url, "token_invalido")
-            xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
-            
-            headers = {
-                "customid": self.generate_custom_id("STP")
-            }
-            
-            response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response.get_status())
-            self.assertEqual("El token debe contener 3 partes", response.get_message())
-            self.assertNotEqual(200, response.status_code)
-        except Exception as e:
-            raise
-
-    def test_stamp_invalid_email_format(self):
-        """Error 4: Stamp con formato de email inválido"""
-        try:
-            stamp = StampV4(self.url, self.token)
-            xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
-            
-            headers = {
-                "customid": self.generate_custom_id("STP"),
-                "email": "correo_invalido"
-            }
-            
-            response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response.get_status())
-            self.assertNotEqual(200, response.status_code)
-            self.assertEqual("El header email no tiene un correo válido (email).", response.get_message())
-        except Exception as e:
-            raise
-
-    def test_issue_duplicate_custom_id(self):
-        """Error 5: Issue - Error al intentar usar un customId duplicado"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            xml_content = self.update_date_xml("Test/resources/xml40.xml")
-            
-            custom_id = self.generate_custom_id("ISS")
-            headers = {
-                "customid": custom_id
-            }
-            
-            response1 = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("success", response1.get_status())
-            self.assertIsNotNone(response1.data.get("cfdi")) #Dato de version 4
-            self.assertIsNotNone(response1.data.get("uuid")) #Dato de version 4 - UUID del comprobante
-            self.assertEqual(200, response1.status_code)
-            
-            response2 = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response2.get_status())
-            self.assertEqual("307. El comprobante contiene un timbre previo.", response2.get_message())
-        except Exception as e:
-            raise
-
-    def test_issue_json_invalid_format(self):
-        """Error 6: Issue JSON con formato inválido"""
-        try:
-            issue = IssueV4(self.url, self.token)
-            json_content = '{"invalid": "json format for cfdi"}'
-            
-            headers = {
-                "customid": self.generate_custom_id("ISJ")
-            }
-            
-            response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
-            
-            self.assertEqual("error", response.get_status())
-            self.assertNotEqual(200, response.status_code)
-            self.assertIsNotNone(response.get_message())
-        except Exception as e:
-            raise
+        new_date = datetime.now() - timedelta(hours=1)
+        if "Fecha" not in root.attrib:
+            raise ValueError("No se encontró el atributo 'Fecha' en el XML")
+        root.set("Fecha", new_date.strftime("%Y-%m-%dT%H:%M:%S"))
+        ET.register_namespace("cfdi", ns["cfdi"])
+        xml_buffer = BytesIO()
+        tree.write(xml_buffer, encoding="utf-8", xml_declaration=True)
+        return xml_buffer.getvalue().decode("utf-8")
 
     @staticmethod
     def update_date_json(path_json):
-        """Actualiza la fecha en un archivo JSON a la hora actual menos 1 hora"""
-        try:
-            with open(path_json, "r", encoding="utf-8") as file:
-                data = json.load(file)
-            
-            new_date = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
-            if "Fecha" in data:
-                data["Fecha"] = new_date
-                return json.dumps(data, indent=2, ensure_ascii=False)
-            else:
-                raise ValueError("No se encontró la clave 'Fecha' en el JSON")
-        except Exception as e:
-            raise
+        with open(path_json, "r", encoding="utf-8") as file:
+            data = json.load(file)
+
+        new_date = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+        if "Fecha" not in data:
+            raise ValueError("No se encontró la clave 'Fecha' en el JSON")
+        data["Fecha"] = new_date
+        return json.dumps(data, indent=2, ensure_ascii=False)
+
+    def esperar_url_pdf(self, uuid):
+        #El PDF del comprobante tarda en quedar disponible en el ADT.
+        storage = Storage(self.url, self.urlApi, self.token)
+        for _ in range(12):
+            time.sleep(10)
+            url_pdf = storage.get_by_uuid(uuid).get_url_pdf()
+            if url_pdf:
+                return url_pdf
+        return None
+
+    #UT Emisión de Timbrado XML
+    def test_issue_xml_auth_all_headers(self):
+        issue = IssueV4(self.url, None, self.user, self.password)
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+
+        response = issue.issue_xml(xml_content,
+                                   custom_id=self.generate_custom_id("ISS"),
+                                   email=["test1@test.com", "test2@test.com"],
+                                   pdf=True,
+                                   version=ResponseVersion.V4)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data)
+        self.assertIsNotNone(response.data.get("cfdi"))
+        self.assertIsNotNone(response.data.get("uuid"))
+        self.assertIsNotNone(self.esperar_url_pdf(response.data.get("uuid")),
+                             "El comprobante se timbró sin generar el PDF en el ADT")
+
+    def test_issue_xml_token_minimal_headers(self):
+        issue = IssueV4(self.url, self.token)
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+
+        response = issue.issue_xml(xml_content,
+                                   custom_id=self.generate_custom_id("ISS"),
+                                   version=ResponseVersion.V3)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data.get("cfdi"))
+
+    def test_issue_xml_headers_dict(self):
+        #El diccionario headers se conserva y sus valores prevalecen sobre los parámetros.
+        issue = IssueV4(self.url, self.token)
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data.get("uuid"))
+
+    def test_issue_xml_b64(self):
+        issue = IssueV4(self.url, self.token)
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+        xml_b64 = b64encode(xml_content.encode("utf-8")).decode()
+
+        response = issue.issue_xml(xml_b64,
+                                   custom_id=self.generate_custom_id("ISS"),
+                                   version=ResponseVersion.V4,
+                                   b64=True)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data.get("uuid"))
+
+    #UT Timbrado XML
+    def test_stamp_token_all_headers(self):
+        stamp = StampV4(self.url, self.token)
+        xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
+
+        response = stamp.stamp(xml_content,
+                               custom_id=self.generate_custom_id("STP"),
+                               email="stamp1@test.com,stamp2@test.com",
+                               pdf=True,
+                               version=ResponseVersion.V2)
+
+        #El comprobante de pruebas ya está timbrado: el servicio responde con el timbre previo.
+        if response.get_status() == "error":
+            self.assertIn("307", response.get_message())
+        else:
+            self.assertEqual("success", response.get_status())
+            self.assertEqual(200, response.status_code)
+            self.assertIsNotNone(response.data.get("tfd"))
+
+    def test_stamp_auth_email_only(self):
+        stamp = StampV4(self.url, None, self.user, self.password)
+        xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
+
+        response = stamp.stamp(xml_content, email="stamp1@test.com", version=ResponseVersion.V4)
+
+        if response.get_status() == "error":
+            self.assertIn("307", response.get_message())
+        else:
+            self.assertEqual("success", response.get_status())
+            self.assertEqual(200, response.status_code)
+
+    def test_stamp_b64(self):
+        stamp = StampV4(self.url, self.token)
+        xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
+        xml_b64 = b64encode(xml_content.encode("utf-8")).decode()
+
+        response = stamp.stamp(xml_b64,
+                               custom_id=self.generate_custom_id("STP"),
+                               version=ResponseVersion.V2,
+                               b64=True)
+
+        if response.get_status() == "error":
+            self.assertIn("307", response.get_message())
+        else:
+            self.assertEqual("success", response.get_status())
+            self.assertEqual(200, response.status_code)
+
+    #UT Emisión de Timbrado JSON
+    def test_issue_json_auth_all_headers(self):
+        issue = IssueV4(self.url, None, self.user, self.password)
+        json_content = self.update_date_json("Test/resources/cfdi.json")
+
+        response = issue.issue_json(json_content,
+                                    custom_id=self.generate_custom_id("ISJ"),
+                                    email=["test1@test.com", "test2@test.com"],
+                                    version=ResponseVersion.V4)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data)
+        self.assertIsNotNone(response.data.get("cfdi"))
+        self.assertIsNotNone(response.data.get("uuid"))
+
+    def test_issue_json_token_minimal_headers(self):
+        issue = IssueV4(self.url, self.token)
+        time.sleep(5)
+        json_content = self.update_date_json("Test/resources/cfdi.json")
+
+        response = issue.issue_json(json_content,
+                                    custom_id=self.generate_custom_id("ISJ"),
+                                    version=ResponseVersion.V3)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data.get("cfdi"))
+
+    def test_issue_json_with_pdf(self):
+        issue = IssueV4(self.url, self.token)
+        time.sleep(5)
+        json_content = self.update_date_json("Test/resources/cfdi.json")
+
+        response = issue.issue_json(json_content,
+                                    custom_id=self.generate_custom_id("ISJ"),
+                                    email="test1@test.com",
+                                    pdf=True,
+                                    version=ResponseVersion.V4)
+
+        self.assertEqual("success", response.get_status())
+        self.assertEqual(200, response.status_code)
+        self.assertIsNotNone(response.data)
+        self.assertIsNotNone(response.data.get("uuid"))
+        self.assertIsNotNone(self.esperar_url_pdf(response.data.get("uuid")),
+                             "El comprobante se timbró sin generar el PDF en el ADT")
+
+    #UT de Error
+    def test_issue_xml_invalid_credentials(self):
+        issue = IssueV4(self.url, None, "usuario_invalido", "pass_invalido")
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+
+        response = issue.issue_xml(xml_content, custom_id=self.generate_custom_id("ISS"), version=ResponseVersion.V4)
+
+        self.assertEqual("error", response.get_status())
+        self.assertNotEqual(200, response.status_code)
+        self.assertIsNone(response.data)
+        self.assertIn("AU4101", response.get_message())
+
+    def test_issue_xml_invalid_xml(self):
+        issue = IssueV4(self.url, self.token)
+
+        response = issue.issue_xml("<xml>mal formado</xml>",
+                                   custom_id=self.generate_custom_id("ISS"),
+                                   version=ResponseVersion.V4)
+
+        self.assertEqual("error", response.get_status())
+        self.assertNotEqual(200, response.status_code)
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
+
+    def test_stamp_invalid_token(self):
+        stamp = StampV4(self.url, "token_invalido")
+        xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
+
+        response = stamp.stamp(xml_content, custom_id=self.generate_custom_id("STP"), version=ResponseVersion.V4)
+
+        self.assertEqual("error", response.get_status())
+        self.assertNotEqual(200, response.status_code)
+        self.assertIn("token", response.get_message().lower())
+
+    def test_stamp_invalid_email_format(self):
+        stamp = StampV4(self.url, self.token)
+        xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
+
+        response = stamp.stamp(xml_content,
+                               custom_id=self.generate_custom_id("STP"),
+                               email="correo_invalido",
+                               version=ResponseVersion.V4)
+
+        self.assertEqual("error", response.get_status())
+        self.assertNotEqual(200, response.status_code)
+        self.assertIn("email", response.get_message().lower())
+
+    def test_issue_duplicate_custom_id(self):
+        issue = IssueV4(self.url, self.token)
+        xml_content = self.update_date_xml("Test/resources/xml40.xml")
+        custom_id = self.generate_custom_id("ISS")
+
+        response1 = issue.issue_xml(xml_content, custom_id=custom_id, version=ResponseVersion.V4)
+
+        self.assertEqual("success", response1.get_status())
+        self.assertEqual(200, response1.status_code)
+        self.assertIsNotNone(response1.data.get("uuid"))
+
+        response2 = issue.issue_xml(xml_content, custom_id=custom_id, version=ResponseVersion.V4)
+
+        self.assertEqual("error", response2.get_status())
+        self.assertIn("307", response2.get_message())
+
+    def test_issue_json_invalid_format(self):
+        issue = IssueV4(self.url, self.token)
+
+        response = issue.issue_json('{"invalid": "json format for cfdi"}',
+                                    custom_id=self.generate_custom_id("ISJ"),
+                                    version=ResponseVersion.V4)
+
+        self.assertEqual("error", response.get_status())
+        self.assertNotEqual(200, response.status_code)
+        self.assertIsNotNone(response.get_message(), "El valor de message esta vacio")
 
 if __name__ == '__main__':
-    try:
-        suite = unittest.TestLoader().loadTestsFromTestCase(TestV4Basic)
-        result = unittest.TextTestRunner(verbosity=2).run(suite)
-        sys.exit(not result.wasSuccessful())
-    except Exception as e:
-        sys.exit(1) 
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestV4Basic)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/Test/test_v4_services.py
+++ b/Test/test_v4_services.py
@@ -75,7 +75,7 @@ class TestV4Basic(unittest.TestCase):
         return None
 
     #UT Emisión de Timbrado XML
-    def test_issue_xml_auth_all_headers(self):
+    def test_issue_xml_auth_named_params(self):
         issue = IssueV4(self.url, None, self.user, self.password)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
 
@@ -97,36 +97,47 @@ class TestV4Basic(unittest.TestCase):
         issue = IssueV4(self.url, self.token)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
 
-        response = issue.issue_xml(xml_content,
-                                   custom_id=self.generate_custom_id("ISS"),
-                                   version=ResponseVersion.V3)
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V3)
 
         self.assertEqual("success", response.get_status())
         self.assertEqual(200, response.status_code)
         self.assertIsNotNone(response.data.get("cfdi"))
 
-    def test_issue_xml_headers_dict(self):
+    def test_issue_xml_headers_over_named_params(self):
         issue = IssueV4(self.url, self.token)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
+
         headers = {
             "customid": self.generate_custom_id("ISS")
         }
 
-        response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
+        response1 = issue.issue_xml(xml_content, headers=headers,
+                                    custom_id=self.generate_custom_id("OTR"),
+                                    version=ResponseVersion.V4)
 
-        self.assertEqual("success", response.get_status())
-        self.assertEqual(200, response.status_code)
-        self.assertIsNotNone(response.data.get("uuid"))
+        self.assertEqual("success", response1.get_status())
+        self.assertEqual(200, response1.status_code)
+
+        #El customid que llegó al servicio es el del diccionario: al repetirlo responde con el timbre previo.
+        response2 = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
+
+        self.assertEqual("error", response2.get_status())
+        self.assertIn("307", response2.get_message())
 
     def test_issue_xml_b64(self):
         issue = IssueV4(self.url, self.token)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
         xml_b64 = b64encode(xml_content.encode("utf-8")).decode()
 
-        response = issue.issue_xml(xml_b64,
-                                   custom_id=self.generate_custom_id("ISS"),
-                                   version=ResponseVersion.V4,
-                                   b64=True)
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response = issue.issue_xml(xml_b64, headers=headers, version=ResponseVersion.V4, b64=True)
 
         self.assertEqual("success", response.get_status())
         self.assertEqual(200, response.status_code)
@@ -137,11 +148,13 @@ class TestV4Basic(unittest.TestCase):
         stamp = StampV4(self.url, self.token)
         xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
 
-        response = stamp.stamp(xml_content,
-                               custom_id=self.generate_custom_id("STP"),
-                               email="stamp1@test.com,stamp2@test.com",
-                               pdf=True,
-                               version=ResponseVersion.V2)
+        headers = {
+            "customid": self.generate_custom_id("STP"),
+            "email": "stamp1@test.com,stamp2@test.com",
+            "extra": "pdf"
+        }
+
+        response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V2)
 
         if response.get_status() == "error":
             self.assertIn("307", response.get_message())
@@ -154,7 +167,11 @@ class TestV4Basic(unittest.TestCase):
         stamp = StampV4(self.url, None, self.user, self.password)
         xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
 
-        response = stamp.stamp(xml_content, email="stamp1@test.com", version=ResponseVersion.V4)
+        headers = {
+            "email": "stamp1@test.com"
+        }
+
+        response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
 
         if response.get_status() == "error":
             self.assertIn("307", response.get_message())
@@ -167,10 +184,11 @@ class TestV4Basic(unittest.TestCase):
         xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
         xml_b64 = b64encode(xml_content.encode("utf-8")).decode()
 
-        response = stamp.stamp(xml_b64,
-                               custom_id=self.generate_custom_id("STP"),
-                               version=ResponseVersion.V2,
-                               b64=True)
+        headers = {
+            "customid": self.generate_custom_id("STP")
+        }
+
+        response = stamp.stamp(xml_b64, headers=headers, version=ResponseVersion.V2, b64=True)
 
         if response.get_status() == "error":
             self.assertIn("307", response.get_message())
@@ -183,10 +201,12 @@ class TestV4Basic(unittest.TestCase):
         issue = IssueV4(self.url, None, self.user, self.password)
         json_content = self.update_date_json("Test/resources/cfdi.json")
 
-        response = issue.issue_json(json_content,
-                                    custom_id=self.generate_custom_id("ISJ"),
-                                    email=["test1@test.com", "test2@test.com"],
-                                    version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISJ"),
+            "email": "test1@test.com,test2@test.com"
+        }
+
+        response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("success", response.get_status())
         self.assertEqual(200, response.status_code)
@@ -199,9 +219,11 @@ class TestV4Basic(unittest.TestCase):
         time.sleep(5)
         json_content = self.update_date_json("Test/resources/cfdi.json")
 
-        response = issue.issue_json(json_content,
-                                    custom_id=self.generate_custom_id("ISJ"),
-                                    version=ResponseVersion.V3)
+        headers = {
+            "customid": self.generate_custom_id("ISJ")
+        }
+
+        response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V3)
 
         self.assertEqual("success", response.get_status())
         self.assertEqual(200, response.status_code)
@@ -212,11 +234,13 @@ class TestV4Basic(unittest.TestCase):
         time.sleep(5)
         json_content = self.update_date_json("Test/resources/cfdi.json")
 
-        response = issue.issue_json(json_content,
-                                    custom_id=self.generate_custom_id("ISJ"),
-                                    email="test1@test.com",
-                                    pdf=True,
-                                    version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISJ"),
+            "email": "test1@test.com",
+            "extra": "pdf"
+        }
+
+        response = issue.issue_json(json_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("success", response.get_status())
         self.assertEqual(200, response.status_code)
@@ -230,7 +254,11 @@ class TestV4Basic(unittest.TestCase):
         issue = IssueV4(self.url, None, "usuario_invalido", "pass_invalido")
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
 
-        response = issue.issue_xml(xml_content, custom_id=self.generate_custom_id("ISS"), version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response.get_status())
         self.assertNotEqual(200, response.status_code)
@@ -240,9 +268,11 @@ class TestV4Basic(unittest.TestCase):
     def test_issue_xml_invalid_xml(self):
         issue = IssueV4(self.url, self.token)
 
-        response = issue.issue_xml("<xml>mal formado</xml>",
-                                   custom_id=self.generate_custom_id("ISS"),
-                                   version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response = issue.issue_xml("<xml>mal formado</xml>", headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response.get_status())
         self.assertNotEqual(200, response.status_code)
@@ -252,7 +282,11 @@ class TestV4Basic(unittest.TestCase):
         stamp = StampV4(self.url, "token_invalido")
         xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
 
-        response = stamp.stamp(xml_content, custom_id=self.generate_custom_id("STP"), version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("STP")
+        }
+
+        response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response.get_status())
         self.assertNotEqual(200, response.status_code)
@@ -262,10 +296,12 @@ class TestV4Basic(unittest.TestCase):
         stamp = StampV4(self.url, self.token)
         xml_content = open("Test/resources/xml40Stamp.xml", "r", encoding='utf-8').read()
 
-        response = stamp.stamp(xml_content,
-                               custom_id=self.generate_custom_id("STP"),
-                               email="correo_invalido",
-                               version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("STP"),
+            "email": "correo_invalido"
+        }
+
+        response = stamp.stamp(xml_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response.get_status())
         self.assertNotEqual(200, response.status_code)
@@ -274,15 +310,18 @@ class TestV4Basic(unittest.TestCase):
     def test_issue_duplicate_custom_id(self):
         issue = IssueV4(self.url, self.token)
         xml_content = self.update_date_xml("Test/resources/xml40.xml")
-        custom_id = self.generate_custom_id("ISS")
 
-        response1 = issue.issue_xml(xml_content, custom_id=custom_id, version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISS")
+        }
+
+        response1 = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("success", response1.get_status())
         self.assertEqual(200, response1.status_code)
         self.assertIsNotNone(response1.data.get("uuid"))
 
-        response2 = issue.issue_xml(xml_content, custom_id=custom_id, version=ResponseVersion.V4)
+        response2 = issue.issue_xml(xml_content, headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response2.get_status())
         self.assertIn("307", response2.get_message())
@@ -290,9 +329,11 @@ class TestV4Basic(unittest.TestCase):
     def test_issue_json_invalid_format(self):
         issue = IssueV4(self.url, self.token)
 
-        response = issue.issue_json('{"invalid": "json format for cfdi"}',
-                                    custom_id=self.generate_custom_id("ISJ"),
-                                    version=ResponseVersion.V4)
+        headers = {
+            "customid": self.generate_custom_id("ISJ")
+        }
+
+        response = issue.issue_json('{"invalid": "json format for cfdi"}', headers=headers, version=ResponseVersion.V4)
 
         self.assertEqual("error", response.get_status())
         self.assertNotEqual(200, response.status_code)

--- a/Utils/requestHelper.py
+++ b/Utils/requestHelper.py
@@ -95,23 +95,25 @@ class RequestHelper:
     @staticmethod
     def post_v4_json(endpoint: str, content: Union[str, dict], token: str = None, headers: Dict = None) -> requests.Response:
         request_headers = {
-            'Authorization': f'Bearer {token}' if token else None,
+            'Authorization': f'bearer {token}' if token else None,
             'Content-Type': 'application/jsontoxml; charset=utf-8'
         }
         if headers:
             request_headers.update(headers)
         if isinstance(content, dict):
             content = json.dumps(content, ensure_ascii=False)
-        return requests.post(endpoint, data=content.encode('utf-8'), headers=request_headers)
+        session = RequestHelper._get_session()
+        return session.post(endpoint, data=content.encode('utf-8'), headers=request_headers, verify=True, timeout=300)
 
     @staticmethod
     def post_v4(endpoint: str, content: Union[str, dict], token: str = None, headers: Dict = None) -> requests.Response:
         request_headers = {
-            'Authorization': f'Bearer {token}' if token else None
+            'Authorization': f'bearer {token}' if token else None
         }
         if headers:
             request_headers.update(headers)
         boundary = ''.join(random.choices(string.ascii_letters + string.digits, k=30))
         request_headers['Content-Type'] = f'multipart/form-data; boundary={boundary}'
         body = RequestHelper._create_multipart_body(content, boundary)
-        return requests.post(endpoint, data=body, headers=request_headers)
+        session = RequestHelper._get_session()
+        return session.post(endpoint, data=body, headers=request_headers, verify=True, timeout=300)

--- a/Utils/response_version.py
+++ b/Utils/response_version.py
@@ -1,11 +1,10 @@
 from enum import Enum
 
 class ResponseVersion(Enum):
-    """Enum for CFDI response versions"""
     V1 = "v1"
     V2 = "v2"
     V3 = "v3"
     V4 = "v4"
-    
+
     def __str__(self):
-        return self.value 
+        return self.value

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 setuptools.setup(
     name='sw-sdk-python',
-    version='0.0.11.1',
+    version='0.0.12.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
     packages=setuptools.find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 setuptools.setup(
     name='sw-sdk-python',
-    version='0.0.8.1',
+    version='0.0.9.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
     packages=setuptools.find_packages(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 setuptools.setup(
     name='sw-sdk-python',
-    version='0.0.9.1',
+    version='0.0.10.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
     packages=setuptools.find_packages(

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ setuptools.setup(
     version='0.0.10.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
-    packages=setuptools.find_packages(
-    license="MIT",),
+    packages=setuptools.find_packages(),
+    license="MIT",
     long_description_content_type="text/markdown",
     long_description=open('README.md',encoding='utf-8').read(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 setuptools.setup(
     name='sw-sdk-python',
-    version='0.0.10.1',
+    version='0.0.11.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
### Actividad
Release 0.0.12.1 — Actualización librerías - Librerías estables - Python

### Qué incluye
- SS-269 — Certificados: consulta de certificados de la cuenta, por RFC y por tipo, certificado activo y eliminación (`0.0.9.1`).
- SS-271 — Recuperar XML por UUID: servicio Storage, con las URLs de descarga del XML y del PDF del comprobante (`0.0.10.1`).
- SS-275 — Regenerar PDF: genera o reemplaza el PDF de un CFDI timbrado en el Administrador de Timbres (`0.0.11.1`).
- SS-274 — Revisión de Timbrado V4: corrige el header de confirmación de PDF a `extra: pdf`, alinea `post_v4` y `post_v4_json` con el resto de los helpers, agrega el formato `b64` y los parámetros de email, customid y pdf, y corrige la documentación de la sección (`0.0.12.1`).

### Versión
`0.0.8.1` → `0.0.12.1`
