### PR TITLE
Feature/ss 272 ss 273

### DIFF
--- a/AccountUser/AccountUser.py
+++ b/AccountUser/AccountUser.py
@@ -16,13 +16,15 @@ class AccountUser(Services):
         return AccountUserRequest.delete_user(self.urlApi,self.get_token(),idUser)
     def update_user(self,idUser,name,taxId,notificationEmail,phone,isUnlimited=False):
         return AccountUserRequest.update_user(self.urlApi,self.get_token(),idUser,name,taxId,notificationEmail,phone,isUnlimited)
-    def getUser_all(self):
-        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"All")
-    def getUser_by_idUser(self,idUser):
-        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"IdUser",idUser)
-    def getUser_by_email(self, email):
-        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"Email",None,email)
-    def getUser_by_taxId(self, taxId):
-        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"TaxId",None,None,taxId)
-    def getUser_by_isActive(self, isActive):
-        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"IsActive",None,None,None,isActive)
+    def getUser_all(self,page=None,perPage=None):
+        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"All",page=page,perPage=perPage)
+    def getUser_by_idUser(self,idUser,page=None,perPage=None):
+        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"IdUser",idUser,page=page,perPage=perPage)
+    def getUser_by_email(self, email,page=None,perPage=None):
+        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"Email",None,email,page=page,perPage=perPage)
+    def getUser_by_taxId(self, taxId,page=None,perPage=None):
+        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"TaxId",None,None,taxId,page=page,perPage=perPage)
+    def getUser_by_isActive(self, isActive,page=None,perPage=None):
+        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"IsActive",None,None,None,isActive,page=page,perPage=perPage)
+    def getUser_by_name(self, name,page=None,perPage=None):
+        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"Name",None,None,None,None,name,page,perPage)

--- a/AccountUser/AccountUser.py
+++ b/AccountUser/AccountUser.py
@@ -27,4 +27,4 @@ class AccountUser(Services):
     def getUser_by_isActive(self, isActive,page=None,perPage=None):
         return AccountUserRequest.get_users(self.urlApi,self.get_token(),"IsActive",None,None,None,isActive,page=page,perPage=perPage)
     def getUser_by_name(self, name,page=None,perPage=None):
-        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"Name",None,None,None,None,name,page,perPage)
+        return AccountUserRequest.get_users(self.urlApi,self.get_token(),"Name",name=name,page=page,perPage=perPage)

--- a/AccountUser/AccountUserRequest.py
+++ b/AccountUser/AccountUserRequest.py
@@ -1,32 +1,43 @@
+from urllib.parse import urlencode
 from AccountUser.AccountUserResponse import AccountUserResponse
 from Utils.requestHelper import RequestHelper
 
 class AccountUserRequest():
     _pathBase = "/management/v2/api/dealers/users"
     @staticmethod
-    def get_path(filter,idUser,email,taxId, isActive):
-        endpoint = AccountUserRequest._pathBase
-        if filter == "All":
-            path = endpoint
-        elif filter == "IdUser":
-            path = endpoint + "/?IdUser=" + idUser
+    def get_path(filter,idUser,email,taxId, isActive, name=None, page=None, perPage=None):
+        """Arma la ruta de consulta con el filtro solicitado y la paginación."""
+        parameters = {}
+        if filter == "IdUser":
+            parameters["IdUser"] = idUser
         elif filter == "Email":
-            path = endpoint + "/?Email=" + email
+            parameters["Email"] = email
         elif filter == "TaxId":
-            path = endpoint + "/?TaxId=" + taxId
+            parameters["TaxId"] = taxId
         elif filter == "IsActive":
-            path = endpoint + "/?IsActive=" + str(isActive)
+            parameters["IsActive"] = isActive
+        elif filter == "Name":
+            parameters["Name"] = name
+        if page is not None:
+            parameters["Page"] = page
+        if perPage is not None:
+            parameters["PerPage"] = perPage
+        path = AccountUserRequest._pathBase
+        if parameters:
+            path = path + "?" + urlencode(parameters)
         return path
-    
+
     @staticmethod
-    def get_users(urlApi,token,filter,idUser=None,email=None,taxId=None, isActive=None):
-        path = AccountUserRequest.get_path(filter,idUser,email,taxId, isActive)
+    def get_users(urlApi,token,filter,idUser=None,email=None,taxId=None, isActive=None, name=None, page=None, perPage=None):
+        """Consulta los usuarios asociados al token, con el filtro y la página indicados."""
+        path = AccountUserRequest.get_path(filter,idUser,email,taxId, isActive, name, page, perPage)
         endpoint = urlApi + path
         response = RequestHelper.get_json_request(endpoint,token)
         return AccountUserResponse(response)
-    
+
     @staticmethod
     def create_user(urlApi,token,name,taxId,email,stamps,isUnlimited,password,notificationEmail,phone):
+        """Da de alta un usuario en la cuenta distribuidora."""
         endpoint = urlApi + AccountUserRequest._pathBase
         payload = {
             "name": name,
@@ -40,15 +51,17 @@ class AccountUserRequest():
         }
         response = RequestHelper.post_json_request(endpoint, token,payload)
         return AccountUserResponse(response)
-    
+
     @staticmethod
     def delete_user(urlApi,token,idUser):
+        """Elimina un usuario de la cuenta distribuidora."""
         endpoint = urlApi + AccountUserRequest._pathBase + f"/{idUser}"
         response = RequestHelper.delete_json_request(endpoint,token)
         return AccountUserResponse(response)
-    
+
     @staticmethod
     def update_user(urlApi,token,idUser,name,taxId,notificationEmail,phone,isUnlimited):
+        """Actualiza los datos de un usuario previamente registrado."""
         endpoint = urlApi + AccountUserRequest._pathBase + f"/{idUser}"
         payload = {
             "idUser": idUser,

--- a/AccountUser/AccountUserResponse.py
+++ b/AccountUser/AccountUserResponse.py
@@ -3,6 +3,8 @@ import traceback
 from Utils.response import Response
 
 class AccountUserResponse(Response):
+    meta = None
+    links = None
     def __init__(self, response):
         try:
             self.status_code = response.status_code
@@ -13,8 +15,10 @@ class AccountUserResponse(Response):
                         self.data = DataItem(self.response["data"])
                     elif isinstance(self.response["data"], list):
                         self.data = DataList(self.response["data"])
-                    elif isinstance(self.response["data"], str):
+                    else:
                         self.data = self.response["data"]
+                    self.meta = self.response.get("meta")
+                    self.links = self.response.get("links")
                     self.status = self.response["status"]
                 else:
                     self.status = self.response["status"]
@@ -31,7 +35,14 @@ class AccountUserResponse(Response):
                 self.messageDetail = response.request
         except Exception:
             traceback.print_exc()
-            
+
+    def get_meta(self):
+        return self.meta
+
+    def get_links(self):
+        return self.links
+
+
 class DataItem:
     def __init__(self, data):
         self.idUser = data.get("idUser", "")

--- a/Balance/Balance.py
+++ b/Balance/Balance.py
@@ -11,17 +11,13 @@ class Balance(Services):
             print("Debe especificar la urlApi")
     
     def get_balance(self):
-        """Consulta el saldo de timbres de la cuenta autenticada."""
         return BalanceRequest.account_balance(self.urlApi, self.get_token())
 
     def get_balance_by_id(self, idUser):
-        """Consulta el saldo de timbres de una cuenta hija a partir de su identificador."""
         return BalanceRequest.account_balance_by_id(self.urlApi, self.get_token(), idUser)
 
     def add_stamps(self, userId, stamps, comment):
-        """Asigna timbres a una cuenta hija desde la cuenta distribuidora."""
         return BalanceRequest.stamp_distribution(self.urlApi, self.get_token(), userId, stamps, comment,"Add")
 
     def remove_stamps(self, userId, stamps, comment):
-        """Remueve timbres de una cuenta hija desde la cuenta distribuidora."""
         return BalanceRequest.stamp_distribution(self.urlApi, self.get_token(), userId, stamps, comment,"Remove")

--- a/Balance/Balance.py
+++ b/Balance/Balance.py
@@ -11,10 +11,17 @@ class Balance(Services):
             print("Debe especificar la urlApi")
     
     def get_balance(self):
+        """Consulta el saldo de timbres de la cuenta autenticada."""
         return BalanceRequest.account_balance(self.urlApi, self.get_token())
-    
+
+    def get_balance_by_id(self, idUser):
+        """Consulta el saldo de timbres de una cuenta hija a partir de su identificador."""
+        return BalanceRequest.account_balance_by_id(self.urlApi, self.get_token(), idUser)
+
     def add_stamps(self, userId, stamps, comment):
+        """Asigna timbres a una cuenta hija desde la cuenta distribuidora."""
         return BalanceRequest.stamp_distribution(self.urlApi, self.get_token(), userId, stamps, comment,"Add")
 
     def remove_stamps(self, userId, stamps, comment):
+        """Remueve timbres de una cuenta hija desde la cuenta distribuidora."""
         return BalanceRequest.stamp_distribution(self.urlApi, self.get_token(), userId, stamps, comment,"Remove")

--- a/Balance/Balance.py
+++ b/Balance/Balance.py
@@ -17,7 +17,7 @@ class Balance(Services):
         return BalanceRequest.account_balance_by_id(self.urlApi, self.get_token(), idUser)
 
     def add_stamps(self, userId, stamps, comment):
-        return BalanceRequest.stamp_distribution(self.urlApi, self.get_token(), userId, stamps, comment,"Add")
+        return BalanceRequest.add_stamps(self.urlApi, self.get_token(), userId, stamps, comment)
 
     def remove_stamps(self, userId, stamps, comment):
-        return BalanceRequest.stamp_distribution(self.urlApi, self.get_token(), userId, stamps, comment,"Remove")
+        return BalanceRequest.remove_stamps(self.urlApi, self.get_token(), userId, stamps, comment)

--- a/Balance/BalanceRequest.py
+++ b/Balance/BalanceRequest.py
@@ -17,16 +17,24 @@ class BalanceRequest:
         return BalanceResponse(response)
 
     @staticmethod
-    def stamp_distribution(urlApi, token, userId, stamps, comment,action):
-        """Asigna o remueve timbres de una cuenta hija."""
+    def add_stamps(urlApi, token, userId, stamps, comment):
+        """Asigna timbres a una cuenta hija."""
         endpoint = f"{urlApi}/management/v2/api/dealers/users/{userId}/stamps"
         payload = {
             "stamps": stamps,
             "comment": comment
         }
-        if action == "Add":
-            response = RequestHelper.post_json_request(endpoint,token,payload)
-        else:
-            response = RequestHelper.delete_json_request(endpoint, token, payload)
+        response = RequestHelper.post_json_request(endpoint,token,payload)
+        return AccountBalanceResponse(response)
+
+    @staticmethod
+    def remove_stamps(urlApi, token, userId, stamps, comment):
+        """Remueve timbres de una cuenta hija."""
+        endpoint = f"{urlApi}/management/v2/api/dealers/users/{userId}/stamps"
+        payload = {
+            "stamps": stamps,
+            "comment": comment
+        }
+        response = RequestHelper.delete_json_request(endpoint, token, payload)
         return AccountBalanceResponse(response)
     

--- a/Balance/BalanceRequest.py
+++ b/Balance/BalanceRequest.py
@@ -26,7 +26,7 @@ class BalanceRequest:
         }
         if action == "Add":
             response = RequestHelper.post_json_request(endpoint,token,payload)
-        elif action == "Remove":
+        else:
             response = RequestHelper.delete_json_request(endpoint, token, payload)
         return AccountBalanceResponse(response)
     

--- a/Balance/BalanceRequest.py
+++ b/Balance/BalanceRequest.py
@@ -4,21 +4,21 @@ from Utils.requestHelper import RequestHelper
 class BalanceRequest:
     @staticmethod
     def account_balance(urlApi, token):
-        """Arma la consulta del saldo de la cuenta autenticada."""
+        """Consulta el saldo de timbres de la cuenta asociada al token."""
         endpoint = urlApi + "/management/v2/api/users/balance"
         response = RequestHelper.get_json_request(endpoint,token,None)
         return BalanceResponse(response)
 
     @staticmethod
     def account_balance_by_id(urlApi, token, idUser):
-        """Arma la consulta del saldo de una cuenta hija a partir de su identificador."""
+        """Consulta el saldo de timbres de una cuenta hija por su idUser."""
         endpoint = f"{urlApi}/management/v2/api/dealers/balance/users/{idUser}"
         response = RequestHelper.get_json_request(endpoint,token,None)
         return BalanceResponse(response)
 
     @staticmethod
     def stamp_distribution(urlApi, token, userId, stamps, comment,action):
-        """Arma la asignación o la remoción de timbres de una cuenta hija."""
+        """Asigna o remueve timbres de una cuenta hija."""
         endpoint = f"{urlApi}/management/v2/api/dealers/users/{userId}/stamps"
         payload = {
             "stamps": stamps,

--- a/Balance/BalanceRequest.py
+++ b/Balance/BalanceRequest.py
@@ -4,12 +4,21 @@ from Utils.requestHelper import RequestHelper
 class BalanceRequest:
     @staticmethod
     def account_balance(urlApi, token):
+        """Arma la consulta del saldo de la cuenta autenticada."""
         endpoint = urlApi + "/management/v2/api/users/balance"
         response = RequestHelper.get_json_request(endpoint,token,None)
         return BalanceResponse(response)
-    
+
+    @staticmethod
+    def account_balance_by_id(urlApi, token, idUser):
+        """Arma la consulta del saldo de una cuenta hija a partir de su identificador."""
+        endpoint = f"{urlApi}/management/v2/api/dealers/balance/users/{idUser}"
+        response = RequestHelper.get_json_request(endpoint,token,None)
+        return BalanceResponse(response)
+
     @staticmethod
     def stamp_distribution(urlApi, token, userId, stamps, comment,action):
+        """Arma la asignación o la remoción de timbres de una cuenta hija."""
         endpoint = f"{urlApi}/management/v2/api/dealers/users/{userId}/stamps"
         payload = {
             "stamps": stamps,

--- a/Balance/BalanceResponse.py
+++ b/Balance/BalanceResponse.py
@@ -3,6 +3,7 @@ import traceback
 from Utils.response import Response
 
 class AccountBalanceResponse(Response):
+    """Respuesta de la asignación y remoción de timbres; data trae el saldo resultante."""
     def __init__(self, response):
         try:
             self.status_code = response.status_code
@@ -24,6 +25,7 @@ class AccountBalanceResponse(Response):
             traceback.print_exc()
 
 class BalanceResponse(Response):
+    """Respuesta de la consulta de saldo, propia o de una cuenta hija."""
     def __init__(self, response):
         try:
             self.status_code = response.status_code
@@ -51,14 +53,14 @@ class Data:
         self.stampsBalance = data.get("stampsBalance", 0)
         self.stampsUsed = data.get("stampsUsed", 0)
         self.stampsAssigned = data.get("stampsAssigned", 0)
-        self.unlimited = data.get("unlimited", False)
+        self.unlimited = data.get("isUnlimited", False)
         self.expirationDate = data.get("expirationDate", "")
         self.lastTransaction = LastTransaction(data["lastTransaction"]) if "lastTransaction" in data else None
 
 class LastTransaction:
     def __init__(self, transaction):
         self.folio = transaction.get("folio", 0)
-        self.idUSer = transaction.get("idUSer", "")
+        self.idUSer = transaction.get("idUser", "")
         self.idUserReceiver = transaction.get("idUserReceiver", "")
         self.nameReceiver = transaction.get("nameReceiver", "")
         self.stampsIn = transaction.get("stampsIn", 0)

--- a/Balance/BalanceResponse.py
+++ b/Balance/BalanceResponse.py
@@ -3,7 +3,6 @@ import traceback
 from Utils.response import Response
 
 class AccountBalanceResponse(Response):
-    """Respuesta de la asignación y remoción de timbres; data trae el saldo resultante."""
     def __init__(self, response):
         try:
             self.status_code = response.status_code
@@ -25,7 +24,6 @@ class AccountBalanceResponse(Response):
             traceback.print_exc()
 
 class BalanceResponse(Response):
-    """Respuesta de la consulta de saldo, propia o de una cuenta hija."""
     def __init__(self, response):
         try:
             self.status_code = response.status_code

--- a/README.md
+++ b/README.md
@@ -1073,7 +1073,7 @@ else:
 	#Obtenemos los datos
 	print(objResponseBalance.data.idUser)
 	print(objResponseBalance.data.idUserBalance)
-    print(objResponseBalance.data.stampsAssigned)
+	print(objResponseBalance.data.stampsAssigned)
 	print(objResponseBalance.data.stampsUsed)
 	print(objResponseBalance.data.stampsBalance)
 ```
@@ -1093,7 +1093,57 @@ else:
 	#Obtenemos los datos
 	print(objResponseBalance.data.idUser)
 	print(objResponseBalance.data.idUserBalance)
-    print(objResponseBalance.data.stampsAssigned)
+	print(objResponseBalance.data.stampsAssigned)
+	print(objResponseBalance.data.stampsUsed)
+	print(objResponseBalance.data.stampsBalance)
+```
+</details>
+
+<details>
+  <summary>Consulta de timbres por ID</summary>
+
+<br>Este método recibe los siguientes parametros:
+* Usuario y contraseña o Token
+* Url Servicios SW
+* Url Api
+* IdUser de la cuenta hija a consultar, como cadena o como uuid.UUID
+
+**Ejemplo de consumo de la libreria para consultar el saldo de una cuenta hija mediante usuario y contraseña**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Balance.Balance import Balance
+
+objBalance = Balance("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, user, password)
+objResponseBalance = objBalance.get_balance_by_id("32501CF2-DC62-4370-B47D-25024C44E131")
+#En caso de error, obtenemos el mensaje
+if objResponseBalance.get_status() ==  "error":
+	print(objResponseBalance.get_message())
+	print(objResponseBalance.get_messageDetail())
+else:
+	#Obtenemos los datos
+	print(objResponseBalance.data.idUser)
+	print(objResponseBalance.data.idUserBalance)
+	print(objResponseBalance.data.stampsAssigned)
+	print(objResponseBalance.data.stampsUsed)
+	print(objResponseBalance.data.stampsBalance)
+```
+
+**Ejemplo de consumo de la libreria para consultar el saldo de una cuenta hija mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from Balance.Balance import Balance
+
+objBalance = Balance("https://services.test.sw.com.mx","https://api.test.sw.com.mx", token)
+objResponseBalance = objBalance.get_balance_by_id("32501CF2-DC62-4370-B47D-25024C44E131")
+#En caso de error, obtenemos el mensaje
+if objResponseBalance.get_status() ==  "error":
+	print(objResponseBalance.get_message())
+	print(objResponseBalance.get_messageDetail())
+else:
+	#Obtenemos los datos
+	print(objResponseBalance.data.idUser)
+	print(objResponseBalance.data.idUserBalance)
+	print(objResponseBalance.data.stampsAssigned)
 	print(objResponseBalance.data.stampsUsed)
 	print(objResponseBalance.data.stampsBalance)
 ```
@@ -1106,9 +1156,9 @@ else:
 * Usuario y contraseña o Token
 * Url Servicios SW
 * Url Api
-* IdUser
+* IdUser de la cuenta hija, como cadena o como uuid.UUID
 * Número de timbres
-* Comentario
+* Comentario del movimiento, opcional
 
 > [!NOTE] 
 > El servicio regresa unicamente la cantidad de timbres despues del abono de timbres.
@@ -1151,9 +1201,9 @@ else:
 * Usuario y contraseña o Token
 * Url Servicios SW
 * Url Api
-* IdUser
+* IdUser de la cuenta hija, como cadena o como uuid.UUID
 * Número de timbres
-* Comentario
+* Comentario del movimiento, opcional
 
 > [!NOTE]
 > El servicio regresa unicamente la cantidad de timbres despues de remover los timbres.

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ if objResponseAccountUser.get_status() ==  "error":
 else:
 	#Procesamiento de la respuesta
 	for Key,Value in objResponseAccountUser.response["data"].items():
-  		print (Key,"=",Value)
+		print (Key,"=",Value)
 ```
 
 **Ejemplo de consumo de la libreria para crear un usuario mediante token**
@@ -588,7 +588,7 @@ if objResponseAccountUser.get_status() ==  "error":
 else:
 	#Procesamiento de la respuesta
 	for Key,Value in objResponseAccountUser.response["data"].items():
-  		print (Key,"=",Value)
+		print (Key,"=",Value)
 ```
 
 :pushpin: ***NOTA:*** La contraseña debe cumplir con las siguientes politicas:
@@ -720,10 +720,17 @@ else:
 <details>
   <summary>Obtener todos los usuarios</summary>
 
-<br>Este método recibe los siguientes parametros:
+<br>La consulta regresa los usuarios asociados al token de la petición, es decir las cuentas hijas de la cuenta padre autenticada.
+
+Este método recibe los siguientes parametros:
 * Usuario y contraseña o Token de la cuenta padre.
 * Url Servicios SW
 * Url Api
+* Página a consultar, opcional
+* Número de registros por página, opcional, hasta 50
+
+> [!NOTE]
+> La consulta viene paginada. Si no se indica el tamaño de página, el servicio regresa los primeros 10 registros y en `get_meta()` se puede consultar cuántos hay en total.
 
 **Ejemplo de consumo de la libreria para obtener todos los usarios de una cuenta administradora o padre**
 ```py
@@ -738,19 +745,19 @@ if objResponseAccountUser.get_status() ==  "error":
 	print(objResponseAccountUser.get_messageDetail())
 else:
 	#Obtenemos los datos de los usuarios
-	for user in response.data.items:
-        print("\tName: ",user.name)
-        print("\tIdDelear: ",user.idDealer)
-        print("\tIdUser: ",user.idUser)
-        print("\t taxId: ",user.taxId)
-        print("\t username: ",user.username)
-        print("\t email: ",user.email)
-        print("\t profile: ",user.profile)
-        print("\t isAcrtive: ",user.isActive)
-        print("\t accessToken: ",user.accessToken)
-        print("\t stamps: ",user.stamps)
-        print("\t phone: ",user.phone)
-        print("\t isUnlimited: ",user.isUnlimited)
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdDelear: ",user.idDealer)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t username: ",user.username)
+		print("\t email: ",user.email)
+		print("\t profile: ",user.profile)
+		print("\t isAcrtive: ",user.isActive)
+		print("\t accessToken: ",user.accessToken)
+		print("\t stamps: ",user.stamps)
+		print("\t phone: ",user.phone)
+		print("\t isUnlimited: ",user.isUnlimited)
 ```
 **Ejemplo de consumo de la libreria para obtener todos los usarios de una cuenta administradora o padre mediante token**
 ```py
@@ -765,19 +772,42 @@ if objResponseAccountUser.get_status() ==  "error":
 	print(objResponseAccountUser.get_messageDetail())
 else:
 	#Obtenemos los datos de los usuarios
-	for user in response.data.items:
-        print("\tName: ",user.name)
-        print("\tIdDelear: ",user.idDealer)
-        print("\tIdUser: ",user.idUser)
-        print("\t taxId: ",user.taxId)
-        print("\t username: ",user.username)
-        print("\t email: ",user.email)
-        print("\t profile: ",user.profile)
-        print("\t isAcrtive: ",user.isActive)
-        print("\t accessToken: ",user.accessToken)
-        print("\t stamps: ",user.stamps)
-        print("\t phone: ",user.phone)
-        print("\t isUnlimited: ",user.isUnlimited)
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdDelear: ",user.idDealer)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t username: ",user.username)
+		print("\t email: ",user.email)
+		print("\t profile: ",user.profile)
+		print("\t isAcrtive: ",user.isActive)
+		print("\t accessToken: ",user.accessToken)
+		print("\t stamps: ",user.stamps)
+		print("\t phone: ",user.phone)
+		print("\t isUnlimited: ",user.isUnlimited)
+```
+
+**Ejemplo de consumo de la libreria para recorrer la consulta por páginas**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from AccountUser.AccountUser import AccountUser
+
+objAccountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx",token)
+objResponseAccountUser = objAccountUser.getUser_all(1, 50)
+#En caso de error, obtenemos el mensaje
+if objResponseAccountUser.get_status() ==  "error":
+	print(objResponseAccountUser.get_message())
+	print(objResponseAccountUser.get_messageDetail())
+else:
+	#Obtenemos la paginación de la consulta
+	meta = objResponseAccountUser.get_meta()
+	print("\t Página: ",meta["page"])
+	print("\t Registros por página: ",meta["perPage"])
+	print("\t Total de registros: ",meta["totalCount"])
+	print("\t Total de páginas: ",meta["totalPages"])
+	#Con el total de páginas se recorren las siguientes
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
 ```
 
 </details>
@@ -789,6 +819,8 @@ else:
 * Url Servicios SW
 * Url Api
 * IdUser
+* Página a consultar, opcional
+* Número de registros por página, opcional, hasta 50
 
 **Ejemplo de consumo de la libreria para obtener usuario por ID**
 ```py
@@ -804,19 +836,19 @@ if objResponseAccountUser.get_status() ==  "error":
 	print(objResponseAccountUser.get_messageDetail())
 else:
 	#Obtenemos la respuesta
-	for user in response.data.items:
-        print("\tName: ",user.name)
-        print("\tIdDelear: ",user.idDealer)
-        print("\tIdUser: ",user.idUser)
-        print("\t taxId: ",user.taxId)
-        print("\t username: ",user.username)
-        print("\t email: ",user.email)
-        print("\t profile: ",user.profile)
-        print("\t isAcrtive: ",user.isActive)
-        print("\t accessToken: ",user.accessToken)
-        print("\t stamps: ",user.stamps)
-        print("\t phone: ",user.phone)
-        print("\t isUnlimited: ",user.isUnlimited)
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdDelear: ",user.idDealer)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t username: ",user.username)
+		print("\t email: ",user.email)
+		print("\t profile: ",user.profile)
+		print("\t isAcrtive: ",user.isActive)
+		print("\t accessToken: ",user.accessToken)
+		print("\t stamps: ",user.stamps)
+		print("\t phone: ",user.phone)
+		print("\t isUnlimited: ",user.isUnlimited)
 ```
 **Ejemplo de consumo de la libreria para obtener usuario por ID mediante el token**
 ```py
@@ -832,19 +864,19 @@ if objResponseAccountUser.get_status() ==  "error":
 	print(objResponseAccountUser.get_messageDetail())
 else:
 	#Obtenemos la respuesta
-	for user in response.data.items:
-        print("\tName: ",user.name)
-        print("\tIdDelear: ",user.idDealer)
-        print("\tIdUser: ",user.idUser)
-        print("\t taxId: ",user.taxId)
-        print("\t username: ",user.username)
-        print("\t email: ",user.email)
-        print("\t profile: ",user.profile)
-        print("\t isAcrtive: ",user.isActive)
-        print("\t accessToken: ",user.accessToken)
-        print("\t stamps: ",user.stamps)
-        print("\t phone: ",user.phone)
-        print("\t isUnlimited: ",user.isUnlimited)
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdDelear: ",user.idDealer)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t username: ",user.username)
+		print("\t email: ",user.email)
+		print("\t profile: ",user.profile)
+		print("\t isAcrtive: ",user.isActive)
+		print("\t accessToken: ",user.accessToken)
+		print("\t stamps: ",user.stamps)
+		print("\t phone: ",user.phone)
+		print("\t isUnlimited: ",user.isUnlimited)
 ```
 </details>
 <details>
@@ -855,6 +887,8 @@ else:
 * Url Servicios SW
 * Url Api
 * Email del usuario a consulta.
+* Página a consultar, opcional
+* Número de registros por página, opcional, hasta 50
 
 **Ejemplo de consumo de la libreria para obtener todos los usuarios**
 ```py
@@ -870,19 +904,19 @@ if objResponseAccountUser.get_status() ==  "error":
 	print(objResponseAccountUser.get_messageDetail())
 else:
 	#Obtenemos la respuesta
-	for user in response.data.items:
-        print("\tName: ",user.name)
-        print("\tIdDelear: ",user.idDealer)
-        print("\tIdUser: ",user.idUser)
-        print("\t taxId: ",user.taxId)
-        print("\t username: ",user.username)
-        print("\t email: ",user.email)
-        print("\t profile: ",user.profile)
-        print("\t isAcrtive: ",user.isActive)
-        print("\t accessToken: ",user.accessToken)
-        print("\t stamps: ",user.stamps)
-        print("\t phone: ",user.phone)
-        print("\t isUnlimited: ",user.isUnlimited)
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdDelear: ",user.idDealer)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t username: ",user.username)
+		print("\t email: ",user.email)
+		print("\t profile: ",user.profile)
+		print("\t isAcrtive: ",user.isActive)
+		print("\t accessToken: ",user.accessToken)
+		print("\t stamps: ",user.stamps)
+		print("\t phone: ",user.phone)
+		print("\t isUnlimited: ",user.isUnlimited)
 ```
 **Ejemplo de consumo de la libreria para obtener todos los usuarios mediante token**
 ```py
@@ -898,19 +932,19 @@ if objResponseAccountUser.get_status() ==  "error":
 	print(objResponseAccountUser.get_messageDetail())
 else:
 	#Obtenemos la respuesta
-	for user in response.data.items:
-        print("\tName: ",user.name)
-        print("\tIdDelear: ",user.idDealer)
-        print("\tIdUser: ",user.idUser)
-        print("\t taxId: ",user.taxId)
-        print("\t username: ",user.username)
-        print("\t email: ",user.email)
-        print("\t profile: ",user.profile)
-        print("\t isAcrtive: ",user.isActive)
-        print("\t accessToken: ",user.accessToken)
-        print("\t stamps: ",user.stamps)
-        print("\t phone: ",user.phone)
-        print("\t isUnlimited: ",user.isUnlimited)
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdDelear: ",user.idDealer)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t username: ",user.username)
+		print("\t email: ",user.email)
+		print("\t profile: ",user.profile)
+		print("\t isAcrtive: ",user.isActive)
+		print("\t accessToken: ",user.accessToken)
+		print("\t stamps: ",user.stamps)
+		print("\t phone: ",user.phone)
+		print("\t isUnlimited: ",user.isUnlimited)
 ```
 </details>
 <details>
@@ -921,6 +955,8 @@ else:
 * Url Servicios SW
 * Url Api
 * RFC del usuario a consultar.
+* Página a consultar, opcional
+* Número de registros por página, opcional, hasta 50
 
 **Ejemplo de consumo de la libreria para obtener todos los usuarios**
 ```py
@@ -936,19 +972,19 @@ if objResponseAccountUser.get_status() ==  "error":
 	print(objResponseAccountUser.get_messageDetail())
 else:
 	#Obtenemos la respuesta
-	for user in response.data.items:
-        print("\tName: ",user.name)
-        print("\tIdDelear: ",user.idDealer)
-        print("\tIdUser: ",user.idUser)
-        print("\t taxId: ",user.taxId)
-        print("\t username: ",user.username)
-        print("\t email: ",user.email)
-        print("\t profile: ",user.profile)
-        print("\t isAcrtive: ",user.isActive)
-        print("\t accessToken: ",user.accessToken)
-        print("\t stamps: ",user.stamps)
-        print("\t phone: ",user.phone)
-        print("\t isUnlimited: ",user.isUnlimited)
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdDelear: ",user.idDealer)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t username: ",user.username)
+		print("\t email: ",user.email)
+		print("\t profile: ",user.profile)
+		print("\t isAcrtive: ",user.isActive)
+		print("\t accessToken: ",user.accessToken)
+		print("\t stamps: ",user.stamps)
+		print("\t phone: ",user.phone)
+		print("\t isUnlimited: ",user.isUnlimited)
 ```
 **Ejemplo de consumo de la libreria para obtener todos los usuarios mediante token**
 ```py
@@ -964,19 +1000,19 @@ if objResponseAccountUser.get_status() ==  "error":
 	print(objResponseAccountUser.get_messageDetail())
 else:
 	#Obtenemos la respuesta
-	for user in response.data.items:
-        print("\tName: ",user.name)
-        print("\tIdDelear: ",user.idDealer)
-        print("\tIdUser: ",user.idUser)
-        print("\t taxId: ",user.taxId)
-        print("\t username: ",user.username)
-        print("\t email: ",user.email)
-        print("\t profile: ",user.profile)
-        print("\t isAcrtive: ",user.isActive)
-        print("\t accessToken: ",user.accessToken)
-        print("\t stamps: ",user.stamps)
-        print("\t phone: ",user.phone)
-        print("\t isUnlimited: ",user.isUnlimited)
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdDelear: ",user.idDealer)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t username: ",user.username)
+		print("\t email: ",user.email)
+		print("\t profile: ",user.profile)
+		print("\t isAcrtive: ",user.isActive)
+		print("\t accessToken: ",user.accessToken)
+		print("\t stamps: ",user.stamps)
+		print("\t phone: ",user.phone)
+		print("\t isUnlimited: ",user.isUnlimited)
 ```
 </details>
 <details>
@@ -987,6 +1023,8 @@ else:
 * Url Servicios SW
 * Url Api
 * Indica si el Usuario es activo o no (true o false)
+* Página a consultar, opcional
+* Número de registros por página, opcional, hasta 50
 
 **Ejemplo de consumo de la libreria para obtener todos los usuarios**
 ```py
@@ -1001,19 +1039,19 @@ if objResponseAccountUser.get_status() ==  "error":
 	print(objResponseAccountUser.get_messageDetail())
 else:
 	#Obtenemos la respuesta
-	for user in response.data.items:
-        print("\tName: ",user.name)
-        print("\tIdDelear: ",user.idDealer)
-        print("\tIdUser: ",user.idUser)
-        print("\t taxId: ",user.taxId)
-        print("\t username: ",user.username)
-        print("\t email: ",user.email)
-        print("\t profile: ",user.profile)
-        print("\t isAcrtive: ",user.isActive)
-        print("\t accessToken: ",user.accessToken)
-        print("\t stamps: ",user.stamps)
-        print("\t phone: ",user.phone)
-        print("\t isUnlimited: ",user.isUnlimited)
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdDelear: ",user.idDealer)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t username: ",user.username)
+		print("\t email: ",user.email)
+		print("\t profile: ",user.profile)
+		print("\t isAcrtive: ",user.isActive)
+		print("\t accessToken: ",user.accessToken)
+		print("\t stamps: ",user.stamps)
+		print("\t phone: ",user.phone)
+		print("\t isUnlimited: ",user.isUnlimited)
 ```
 **Ejemplo de consumo de la libreria para obtener todos los usuarios mediante token**
 ```py
@@ -1028,19 +1066,70 @@ if objResponseAccountUser.get_status() ==  "error":
 	print(objResponseAccountUser.get_messageDetail())
 else:
 	#Obtenemos la respuesta
-	for user in response.data.items:
-        print("\tName: ",user.name)
-        print("\tIdDelear: ",user.idDealer)
-        print("\tIdUser: ",user.idUser)
-        print("\t taxId: ",user.taxId)
-        print("\t username: ",user.username)
-        print("\t email: ",user.email)
-        print("\t profile: ",user.profile)
-        print("\t isAcrtive: ",user.isActive)
-        print("\t accessToken: ",user.accessToken)
-        print("\t stamps: ",user.stamps)
-        print("\t phone: ",user.phone)
-        print("\t isUnlimited: ",user.isUnlimited)
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdDelear: ",user.idDealer)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t username: ",user.username)
+		print("\t email: ",user.email)
+		print("\t profile: ",user.profile)
+		print("\t isAcrtive: ",user.isActive)
+		print("\t accessToken: ",user.accessToken)
+		print("\t stamps: ",user.stamps)
+		print("\t phone: ",user.phone)
+		print("\t isUnlimited: ",user.isUnlimited)
+```
+</details>
+<details>
+  <summary>Obtener usuarios por nombre</summary>
+
+<br>Este método recibe los siguientes parametros:
+* Usuario y contraseña o Token de la cuenta padre.
+* Url Servicios SW
+* Url Api
+* Nombre del usuario a consultar
+* Página a consultar, opcional
+* Número de registros por página, opcional, hasta 50
+
+**Ejemplo de consumo de la libreria para obtener los usuarios por nombre**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from AccountUser.AccountUser import AccountUser
+
+objAccountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx",None,user,password)
+objResponseAccountUser = objAccountUser.getUser_by_name("Cliente de prueba")
+#En caso de error, obtenemos el mensaje
+if objResponseAccountUser.get_status() ==  "error":
+	print(objResponseAccountUser.get_message())
+	print(objResponseAccountUser.get_messageDetail())
+else:
+	#Una consulta sin coincidencias regresa la lista vacía
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t email: ",user.email)
+```
+
+**Ejemplo de consumo de la libreria para obtener los usuarios por nombre mediante token**
+```py
+#Importar la clase al comienzo de nuestro programa de la siguiente manera
+from AccountUser.AccountUser import AccountUser
+
+objAccountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx",token)
+objResponseAccountUser = objAccountUser.getUser_by_name("Cliente de prueba")
+#En caso de error, obtenemos el mensaje
+if objResponseAccountUser.get_status() ==  "error":
+	print(objResponseAccountUser.get_message())
+	print(objResponseAccountUser.get_messageDetail())
+else:
+	#Una consulta sin coincidencias regresa la lista vacía
+	for user in objResponseAccountUser.data.items:
+		print("\tName: ",user.name)
+		print("\tIdUser: ",user.idUser)
+		print("\t taxId: ",user.taxId)
+		print("\t email: ",user.email)
 ```
 </details>
 

--- a/Test/test_accountUser.py
+++ b/Test/test_accountUser.py
@@ -1,6 +1,9 @@
 import unittest
 import os
+import random
+import string
 import sys
+from datetime import datetime
 
 #Función para poder importar módulos necesarios.
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
@@ -10,159 +13,259 @@ from AccountUser.AccountUser import AccountUser
 
 class TestAccountUser(unittest.TestCase):
     expected = "success"
-     
-    @unittest.skip("Se omite para evitar afectar UT")
-    def testAccountUser_create_user_auth(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        name = "Prueba UT Hijo Python"
-        taxId = "XAXX010101000"
-        email = f"userPython_{os.environ['SDKTEST_USER']}"
-        password = f"_{os.environ['SDKTEST_PASSWORD']}"
-        notificationEmail = f"user_{os.environ['SDKTEST_USER']}"
-        phone = "0000000000"
-        response = accountUser.create_user(name,taxId,email,1,False,password,notificationEmail,phone)
-        message_expect = f"El email '{email}' ya esta en uso."
-        self.assertTrue(self.expected == response.get_status() or message_expect == response.get_message())
-        
-    @unittest.skip("Se omite para evitar afectar UT")
-    def testAccountUser_update_user_auth(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        idUser = "b9e42c65-4afa-45a2-9b0d-d67b1373a7f4"
-        name = "Prueba UT Hijo Python Actualizado"
-        taxId = "XAXX010101002"
-        phone = "0000000001"
-        response = accountUser.update_user(idUser,name,taxId,None,phone,False)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(idUser == response.get_data())
-        
+    expectedError = "error"
+    url = "https://services.test.sw.com.mx"
+    urlApi = "https://api.test.sw.com.mx"
+    taxId = "XAXX010101000"
+    phone = "0000000000"
+    notFoundId = "00000000-0000-0000-0000-000000000000"
+    invalidId = "no-es-uuid"
+    _firstUser = None
+
+    @classmethod
+    def first_user(cls):
+        #Los datos de consulta se toman de la propia cuenta, nunca se hardcodean.
+        if cls._firstUser is None:
+            accountUser = AccountUser(cls.url, cls.urlApi, os.environ["SDKTEST_TOKEN"])
+            response = accountUser.getUser_all()
+            if response.get_status() != cls.expected or not response.data.items:
+                raise unittest.SkipTest("La cuenta de pruebas no tiene cuentas hijas")
+            cls._firstUser = response.data.items[0]
+        return cls._firstUser
+
+    @staticmethod
+    def generate_email():
+        letters = ''.join(random.choices(string.ascii_lowercase, k=4))
+        timestamp = datetime.now().strftime("%d%H%M%S")
+        return f"ut.python.{letters}{timestamp}@example.com"
+
+    @staticmethod
+    def generate_password():
+        #La contraseña se genera cumpliendo la política del servicio, nunca se escribe en el código.
+        upper = ''.join(random.choices(string.ascii_uppercase, k=3))
+        lower = ''.join(random.choices(string.ascii_lowercase, k=3))
+        numbers = ''.join(random.choices(string.digits, k=3))
+        return f"{upper}{lower}{numbers}$"
+
     #UT Auth consulta de usuarios
     def testAccountUser_all_auth(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
+        accountUser = AccountUser(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
         response = accountUser.getUser_all()
-        self.assertTrue(self.expected == response.get_status())
+        self.assertEqual(self.expected, response.get_status())
         self.assertTrue(len(response.data.items) > 0)
-    
+
     def testAccountUser_by_idUser_auth(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        idUser = "32501CF2-DC62-4370-B47D-25024C44E131"
-        response = accountUser.getUser_by_idUser(idUser)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) > 0) 
-        for user in response.data.items:
-            print("\tName: ",user.name)
-            print("\tIdDelear: ",user.idDealer)
-            print("\tIdUser: ",user.idUser)
-            print("\t taxId: ",user.taxId)
-            print("\t username: ",user.username)
-            print("\t email: ",user.email)
-            print("\t profile: ",user.profile)
-            print("\t isAcrtive: ",user.isActive)
-            print("\t accessToken: ",user.accessToken)
-            print("\t stamps: ",user.stamps)
-            print("\t phone: ",user.phone)
-            print("\t isUnlimited: ",user.isUnlimited)
-        
-    def testAccountUser_by_email_auth(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        email = f"userPython_{os.environ['SDKTEST_USER']}"
-        response = accountUser.getUser_by_email(email)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) > 0) 
-        
-    def testAccountUser_by_taxId_auth(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        taxId = "AAAA000101010"
-        response = accountUser.getUser_by_taxId(taxId)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) > 0)  
-        
-    def testAccountUser_by_isActive_auth(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        response = accountUser.getUser_by_isActive(True)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) > 0) 
-        
-     #UT Token consulta de usuarios
-    def testAccountUser_all(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ['SDKTEST_TOKEN'])
-        response = accountUser.getUser_all()
-        self.assertTrue(self.expected == response.get_status())
+        accountUser = AccountUser(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        response = accountUser.getUser_by_idUser(self.first_user().idUser)
+        self.assertEqual(self.expected, response.get_status())
         self.assertTrue(len(response.data.items) > 0)
-    
-    def testAccountUser_by_idUser(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ['SDKTEST_TOKEN'])
-        idUser = "32501CF2-DC62-4370-B47D-25024C44E131"
-        response = accountUser.getUser_by_idUser(idUser)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) > 0) 
-        
-    def testAccountUser_by_email(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ['SDKTEST_TOKEN'])
-        email = f"userPython_{os.environ['SDKTEST_USER']}"
-        response = accountUser.getUser_by_email(email)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) > 0) 
-        
-    def testAccountUser_by_taxId(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ['SDKTEST_TOKEN'])
-        taxId = "AAAA000101010"
-        response = accountUser.getUser_by_taxId(taxId)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) > 0)  
-        
-    def testAccountUser_by_isActive(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ['SDKTEST_TOKEN'])
+
+    def testAccountUser_by_email_auth(self):
+        accountUser = AccountUser(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        response = accountUser.getUser_by_email(self.first_user().email)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertTrue(len(response.data.items) > 0)
+
+    def testAccountUser_by_taxId_auth(self):
+        accountUser = AccountUser(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        response = accountUser.getUser_by_taxId(self.first_user().taxId)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertTrue(len(response.data.items) > 0)
+
+    def testAccountUser_by_isActive_auth(self):
+        accountUser = AccountUser(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
         response = accountUser.getUser_by_isActive(True)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) > 0) 
-        
-    @unittest.skip("Evitar conflictos por temas de saldos")  
-    def testAccountUser_delete_user_auth(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        idUser = "8e6ec77d-b4d6-47aa-95b9-89b354d8207b"
-        response = accountUser.delete_user(idUser)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertIsNotNone(response.get_data())
-        
-    #UT de Error
-    def testAccountUser_by_idUser_error(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ['SDKTEST_TOKEN'])
-        idUser = "00000CF2-DC62-4370-B47D-25024C44E000"
+        self.assertEqual(self.expected, response.get_status())
+        self.assertTrue(len(response.data.items) > 0)
+
+    def testAccountUser_by_name_auth(self):
+        accountUser = AccountUser(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        response = accountUser.getUser_by_name(self.first_user().name)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertTrue(len(response.data.items) > 0)
+
+    #UT Token consulta de usuarios
+    def testAccountUser_all(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_all()
+        self.assertEqual(self.expected, response.get_status())
+        self.assertTrue(len(response.data.items) > 0)
+        for user in response.data.items:
+            self.assertIsNotNone(user.idUser)
+            self.assertIsNotNone(user.name)
+            self.assertIsNotNone(user.email)
+
+    def testAccountUser_by_idUser(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        idUser = self.first_user().idUser
         response = accountUser.getUser_by_idUser(idUser)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) == 0) 
-        
-    def testAccountUser_by_email_error(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ['SDKTEST_TOKEN'])
-        email = "prueba@example.com"
-        response = accountUser.getUser_by_email(email)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) == 0) 
-        
-    def testAccountUser_by_taxId_error(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ['SDKTEST_TOKEN'])
-        taxId = "AAAA000101011"
-        response = accountUser.getUser_by_taxId(taxId)
-        self.assertTrue(self.expected == response.get_status())
-        self.assertTrue(len(response.data.items) == 0)  
-         
-    def testAccountUser_delete_user_auth_error(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        idUser = "8e6ec77d-b4d6-47aa-95b9-89b354d8207c"
-        response = accountUser.delete_user(idUser)
-        self.assertTrue("error" == response.get_status())
+        self.assertEqual(self.expected, response.get_status())
+        self.assertEqual(1, len(response.data.items))
+        self.assertEqual(idUser.lower(), response.data.items[0].idUser.lower())
+
+    def testAccountUser_by_email(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_by_email(self.first_user().email)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertTrue(len(response.data.items) > 0)
+
+    def testAccountUser_by_taxId(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_by_taxId(self.first_user().taxId)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertTrue(len(response.data.items) > 0)
+
+    def testAccountUser_by_isActive(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_by_isActive(True)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertTrue(len(response.data.items) > 0)
+
+    def testAccountUser_by_name(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_by_name(self.first_user().name)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertTrue(len(response.data.items) > 0)
+
+    #UT Paginación de la consulta
+    def testAccountUser_pagination(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_all(1, 1)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertTrue(len(response.data.items) <= 1)
+        self.assertEqual(1, response.get_meta()["page"])
+        self.assertEqual(1, response.get_meta()["perPage"])
+        self.assertIsNotNone(response.get_links())
+
+    def testAccountUser_pagination_emptyPage(self):
+        #Una página sin resultados responde success con la lista vacía, no es un error.
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_all(999)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertEqual(0, len(response.data.items))
+        self.assertEqual(999, response.get_meta()["page"])
+
+    def testAccountUser_pagination_invalidPerPage(self):
+        #El servicio es quien limita el tamaño de página.
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_all(1, 100)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
         self.assertIsNotNone(response.get_message())
-        
-    def testAccountUser_update_user_auth_error(self):
-        accountUser = AccountUser("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        idUser = "b9e42c65-4afa-45a2-9b0d-d67b1373a7f4"
-        name = "Prueba UT Hijo Python Actualizado"
-        taxId = "XAXX010101002"
-        phone = "0000000001"
-        message_expect = "No es posible actualizar, los datos enviados son identicos a los actuales"
-        response = accountUser.update_user(idUser,name,taxId,None,phone,False)
-        self.assertTrue("error"== response.get_status())
-        self.assertTrue(message_expect== response.get_message())
-    
-suite = unittest.TestLoader().loadTestsFromTestCase(TestAccountUser)
-unittest.TextTestRunner(verbosity=2).run(suite)
+
+    #UT Alta, actualización y baja de usuarios
+    #El usuario que se crea se elimina en la misma prueba, de modo que la cuenta queda como estaba.
+    def testAccountUser_lifecycle(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        email = self.generate_email()
+        alta = accountUser.create_user("Prueba UT Python", self.taxId, email, 0, False,
+                                       self.generate_password(), email, self.phone)
+        self.assertEqual(self.expected, alta.get_status())
+        #El alta regresa el usuario creado, la actualización y la baja regresan su idUser.
+        idUser = alta.data.idUser
+        self.assertIsNotNone(idUser)
+        self.addCleanup(accountUser.delete_user, idUser)
+
+        consulta = accountUser.getUser_by_email(email)
+        self.assertEqual(self.expected, consulta.get_status())
+        self.assertEqual(1, len(consulta.data.items))
+        self.assertEqual(idUser.lower(), consulta.data.items[0].idUser.lower())
+
+        actualizacion = accountUser.update_user(idUser, "Prueba UT Python Editado", self.taxId, email, "0000000001")
+        self.assertEqual(self.expected, actualizacion.get_status())
+        self.assertEqual(idUser, actualizacion.get_data())
+
+        baja = accountUser.delete_user(idUser)
+        self.assertEqual(self.expected, baja.get_status())
+        self.assertIsNotNone(baja.get_data())
+        self.assertEqual(0, len(accountUser.getUser_by_email(email).data.items))
+
+    def testAccountUser_lifecycle_auth(self):
+        accountUser = AccountUser(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        email = self.generate_email()
+        alta = accountUser.create_user("Prueba UT Python", self.taxId, email, 0, False,
+                                       self.generate_password(), email, self.phone)
+        self.assertEqual(self.expected, alta.get_status())
+        idUser = alta.data.idUser
+        self.addCleanup(accountUser.delete_user, idUser)
+
+        baja = accountUser.delete_user(idUser)
+        self.assertEqual(self.expected, baja.get_status())
+        self.assertIsNotNone(baja.get_data())
+
+    def testAccountUser_update_sameData(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        email = self.generate_email()
+        alta = accountUser.create_user("Prueba UT Python", self.taxId, email, 0, False,
+                                       self.generate_password(), email, self.phone)
+        self.assertEqual(self.expected, alta.get_status())
+        idUser = alta.data.idUser
+        self.addCleanup(accountUser.delete_user, idUser)
+        response = accountUser.update_user(idUser, "Prueba UT Python", self.taxId, email, self.phone)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertIsNotNone(response.get_message())
+
+    #UT Consultas sin coincidencias
+    def testAccountUser_by_idUser_notFound(self):
+        #Una consulta sin coincidencias responde success con la lista vacía, no es un error.
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_by_idUser(self.notFoundId)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertEqual(0, len(response.data.items))
+
+    def testAccountUser_by_email_notFound(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_by_email("sin.coincidencias@example.com")
+        self.assertEqual(self.expected, response.get_status())
+        self.assertEqual(0, len(response.data.items))
+
+    def testAccountUser_by_taxId_notFound(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_by_taxId("AAAA000101011")
+        self.assertEqual(self.expected, response.get_status())
+        self.assertEqual(0, len(response.data.items))
+
+    #UT de Error
+    def testAccountUser_by_idUser_invalid(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.getUser_by_idUser(self.invalidId)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertIsNotNone(response.get_message())
+
+    def testAccountUser_create_duplicatedEmail(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        email = self.first_user().email
+        response = accountUser.create_user("Prueba UT Python", self.taxId, email, 0, False,
+                                           self.generate_password(), email, self.phone)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+    def testAccountUser_create_invalidPassword(self):
+        #El servicio es quien valida la política de la contraseña.
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        email = self.generate_email()
+        response = accountUser.create_user("Prueba UT Python", self.taxId, email, 0, False,
+                                           "1234", email, self.phone)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+    def testAccountUser_delete_notFound(self):
+        accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = accountUser.delete_user(self.notFoundId)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(404, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+    def testAccountUser_invalidToken(self):
+        accountUser = AccountUser(self.url, self.urlApi, "token-invalido")
+        response = accountUser.getUser_all()
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(401, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestAccountUser)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/Test/test_accountUser.py
+++ b/Test/test_accountUser.py
@@ -153,8 +153,10 @@ class TestAccountUser(unittest.TestCase):
         self.assertEqual(400, response.get_status_code())
         self.assertIsNotNone(response.get_message())
 
-    #UT Alta, actualización y baja de usuarios
-    #El usuario que se crea se elimina en la misma prueba, de modo que la cuenta queda como estaba.
+    #UT Alta, actualización y baja de usuarios, destructivas: dan de alta una cuenta real en el
+    #distribuidor y la eliminan en la misma prueba, de modo que la cuenta queda como estaba.
+    #Para ejecutarlas basta con definir SDKTEST_USER_LIFECYCLE.
+    @unittest.skipUnless(os.environ.get("SDKTEST_USER_LIFECYCLE"), "Prueba destructiva, definir SDKTEST_USER_LIFECYCLE para ejecutarla")
     def testAccountUser_lifecycle(self):
         accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
         email = self.generate_email()
@@ -180,6 +182,7 @@ class TestAccountUser(unittest.TestCase):
         self.assertIsNotNone(baja.get_data())
         self.assertEqual(0, len(accountUser.getUser_by_email(email).data.items))
 
+    @unittest.skipUnless(os.environ.get("SDKTEST_USER_LIFECYCLE"), "Prueba destructiva, definir SDKTEST_USER_LIFECYCLE para ejecutarla")
     def testAccountUser_lifecycle_auth(self):
         accountUser = AccountUser(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
         email = self.generate_email()
@@ -193,6 +196,7 @@ class TestAccountUser(unittest.TestCase):
         self.assertEqual(self.expected, baja.get_status())
         self.assertIsNotNone(baja.get_data())
 
+    @unittest.skipUnless(os.environ.get("SDKTEST_USER_LIFECYCLE"), "Prueba destructiva, definir SDKTEST_USER_LIFECYCLE para ejecutarla")
     def testAccountUser_update_sameData(self):
         accountUser = AccountUser(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
         email = self.generate_email()

--- a/Test/test_balance.py
+++ b/Test/test_balance.py
@@ -76,7 +76,7 @@ class TestBalance(unittest.TestCase):
         self.assertIsNotNone(response.data.stampsBalance)
 
     def testBalanceById_uuid(self):
-        #El identificador se acepta como cadena o como uuid.UUID.
+        #El idUser también se acepta como uuid.UUID, no sólo como cadena.
         idUser = self.child_user_id()
         balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
         response = balance.get_balance_by_id(uuid.UUID(idUser))
@@ -130,7 +130,6 @@ class TestBalance(unittest.TestCase):
         self.assertEqual(inicial, remove.get_data())
 
     def testBalance_stamps_uuid(self):
-        #El identificador se acepta como cadena o como uuid.UUID.
         idUser = uuid.UUID(self.child_user_id())
         balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
         add = balance.add_stamps(idUser, 1, self.comment)

--- a/Test/test_balance.py
+++ b/Test/test_balance.py
@@ -133,8 +133,10 @@ class TestBalance(unittest.TestCase):
         idUser = uuid.UUID(self.child_user_id())
         balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
         add = balance.add_stamps(idUser, 1, self.comment)
-        self.assertEqual(self.expected, add.get_status())
-        remove = balance.remove_stamps(idUser, 1, self.comment)
+        try:
+            self.assertEqual(self.expected, add.get_status())
+        finally:
+            remove = balance.remove_stamps(idUser, 1, self.comment)
         self.assertEqual(self.expected, remove.get_status())
         self.assertEqual(add.get_data() - 1, remove.get_data())
 
@@ -143,8 +145,10 @@ class TestBalance(unittest.TestCase):
         idUser = self.child_user_id()
         balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
         add = balance.add_stamps(idUser, 1, None)
-        self.assertEqual(self.expected, add.get_status())
-        remove = balance.remove_stamps(idUser, 1, "")
+        try:
+            self.assertEqual(self.expected, add.get_status())
+        finally:
+            remove = balance.remove_stamps(idUser, 1, "")
         self.assertEqual(self.expected, remove.get_status())
         self.assertEqual(add.get_data() - 1, remove.get_data())
 

--- a/Test/test_balance.py
+++ b/Test/test_balance.py
@@ -1,69 +1,213 @@
 import unittest
 import os
 import sys
+import uuid
 
 #Función para poder importar módulos necesarios.
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 sys.path.append(PROJECT_ROOT)
 
+from AccountUser.AccountUser import AccountUser
 from Balance.Balance import Balance
 
 class TestBalance(unittest.TestCase):
     expected = "success"
-    
-    def testBalance_auth(self):
-        balance = Balance("https://services.test.sw.com.mx","https://api.test.sw.com.mx", None, os.environ['SDKTEST_USER'], os.environ['SDKTEST_PASSWORD'])
-        response = balance.get_balance()
-        self.assertTrue(self.expected == response.get_status())
-        self.assertIsNotNone(response.get_data())
-        self.assertIsNotNone(response.data.idUser)
-        self.assertIsNotNone(response.data.idUserBalance)
-        self.assertIsNotNone(response.data.stampsAssigned)
-        self.assertIsNotNone(response.data.stampsUsed)
-        self.assertIsNotNone(response.data.stampsBalance)
-        
-    def testBalance(self):
-        balance = Balance("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ["SDKTEST_TOKEN"])
-        response = balance.get_balance()
-        self.assertTrue(self.expected == response.get_status())
-        self.assertIsNotNone(response.get_data())
-        self.assertIsNotNone(response.data.idUser)
-        self.assertIsNotNone(response.data.idUserBalance)
-        self.assertIsNotNone(response.data.stampsAssigned)
-        self.assertIsNotNone(response.data.stampsUsed)
-        self.assertIsNotNone(response.data.stampsBalance)
-        
-    @unittest.skip("Evitar conflictos por temas de saldos")
-    def testBalance_add_auth(self):
-        balance = Balance("https://services.test.sw.com.mx","https://api.test.sw.com.mx",None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
-        response = balance.add_stamps("32501CF2-DC62-4370-B47D-25024C44E131",1,"Prueba Pyhton")
-        self.assertTrue(self.expected == response.get_status())
-        self.assertIsNotNone(response.get_data())
-        print(response.get_data())
-        
-    @unittest.skip("Evitar conflictos por temas de saldos")
-    def testBalance_add(self):
-        balance = Balance("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ["SDKTEST_TOKEN"])
-        response = balance.add_stamps("32501CF2-DC62-4370-B47D-25024C44E131",1,"Prueba Pyhton")
-        self.assertTrue(self.expected == response.get_status())
-        self.assertIsNotNone(response.get_data())
-        print(response.get_data())
-        
-    @unittest.skip("Evitar conflictos por temas de saldos")
-    def testBalance_remove_auth(self):
-        balance = Balance("https://services.test.sw.com.mx","https://api.test.sw.com.mx",None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
-        response = balance.remove_stamps("32501CF2-DC62-4370-B47D-25024C44E131",1,"Prueba Pyhton")
-        self.assertTrue(self.expected == response.get_status())
-        self.assertIsNotNone(response.get_data())
-        print(response.get_data())
-      
-    @unittest.skip("Evitar conflictos por temas de saldos")  
-    def testBalance_remove(self):
-        balance = Balance("https://services.test.sw.com.mx","https://api.test.sw.com.mx", os.environ["SDKTEST_TOKEN"])
-        response = balance.remove_stamps("32501CF2-DC62-4370-B47D-25024C44E131",1,"Prueba Pyhton")
-        self.assertTrue(self.expected == response.get_status())
-        self.assertIsNotNone(response.get_data())
-        print(response.get_data())
+    expectedError = "error"
+    url = "https://services.test.sw.com.mx"
+    urlApi = "https://api.test.sw.com.mx"
+    comment = "Prueba unitaria Python"
+    #Identificadores que el servicio rechaza, usados en las pruebas de error.
+    invalidId = "no-es-uuid"
+    notFoundId = "00000000-0000-0000-0000-000000000000"
+    _childUserId = None
 
-suite = unittest.TestLoader().loadTestsFromTestCase(TestBalance)
-unittest.TextTestRunner(verbosity=2).run(suite)
+    @classmethod
+    def child_user_id(cls):
+        #El idUser se toma de la propia cuenta distribuidora, nunca se hardcodea.
+        if cls._childUserId is None:
+            accountUser = AccountUser(cls.url, cls.urlApi, os.environ["SDKTEST_TOKEN"])
+            response = accountUser.getUser_all()
+            if response.get_status() != cls.expected or not response.data.items:
+                raise unittest.SkipTest("La cuenta de pruebas no tiene cuentas hijas")
+            cls._childUserId = response.data.items[0].idUser
+        return cls._childUserId
+
+    #UT Consulta del saldo propio
+    def testBalance_auth(self):
+        balance = Balance(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        response = balance.get_balance()
+        self.assertEqual(self.expected, response.get_status())
+        self.assertIsNotNone(response.get_data())
+        self.assertIsNotNone(response.data.idUser)
+        self.assertIsNotNone(response.data.idUserBalance)
+        self.assertIsNotNone(response.data.stampsAssigned)
+        self.assertIsNotNone(response.data.stampsUsed)
+        self.assertIsNotNone(response.data.stampsBalance)
+
+    def testBalance(self):
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.get_balance()
+        self.assertEqual(self.expected, response.get_status())
+        self.assertIsNotNone(response.get_data())
+        self.assertIsNotNone(response.data.idUser)
+        self.assertIsNotNone(response.data.idUserBalance)
+        self.assertIsNotNone(response.data.stampsAssigned)
+        self.assertIsNotNone(response.data.stampsUsed)
+        self.assertIsNotNone(response.data.stampsBalance)
+
+    #UT Consulta del saldo de una cuenta hija
+    def testBalanceById_auth(self):
+        idUser = self.child_user_id()
+        balance = Balance(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        response = balance.get_balance_by_id(idUser)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertEqual(idUser.lower(), response.data.idUser.lower())
+        self.assertIsNotNone(response.data.stampsBalance)
+
+    def testBalanceById(self):
+        idUser = self.child_user_id()
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.get_balance_by_id(idUser)
+        self.assertEqual(self.expected, response.get_status())
+        self.assertEqual(idUser.lower(), response.data.idUser.lower())
+        self.assertIsNotNone(response.data.idUserBalance)
+        self.assertIsNotNone(response.data.stampsAssigned)
+        self.assertIsNotNone(response.data.stampsUsed)
+        self.assertIsNotNone(response.data.stampsBalance)
+
+    def testBalanceById_uuid(self):
+        #El identificador se acepta como cadena o como uuid.UUID.
+        idUser = self.child_user_id()
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.get_balance_by_id(uuid.UUID(idUser))
+        self.assertEqual(self.expected, response.get_status())
+        self.assertEqual(idUser.lower(), response.data.idUser.lower())
+
+    def testBalanceById_invalidId(self):
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.get_balance_by_id(self.invalidId)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+    def testBalanceById_notFound(self):
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.get_balance_by_id(self.notFoundId)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(404, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+    #UT Asignación y remoción de timbres
+    #El ciclo agrega y remueve la misma cantidad, de modo que el saldo queda como estaba.
+    def testBalance_stamps_auth(self):
+        idUser = self.child_user_id()
+        balance = Balance(self.url, self.urlApi, None, os.environ["SDKTEST_USER"], os.environ["SDKTEST_PASSWORD"])
+        inicial = balance.get_balance_by_id(idUser).data.stampsBalance
+        add = balance.add_stamps(idUser, 1, self.comment)
+        self.assertEqual(self.expected, add.get_status())
+        self.assertEqual(inicial + 1, add.get_data())
+        try:
+            consulta = balance.get_balance_by_id(idUser)
+            self.assertEqual(inicial + 1, consulta.data.stampsBalance)
+        finally:
+            remove = balance.remove_stamps(idUser, 1, self.comment)
+        self.assertEqual(self.expected, remove.get_status())
+        self.assertEqual(inicial, remove.get_data())
+
+    def testBalance_stamps(self):
+        idUser = self.child_user_id()
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        inicial = balance.get_balance_by_id(idUser).data.stampsBalance
+        add = balance.add_stamps(idUser, 1, self.comment)
+        self.assertEqual(self.expected, add.get_status())
+        self.assertEqual(inicial + 1, add.get_data())
+        try:
+            consulta = balance.get_balance_by_id(idUser)
+            self.assertEqual(inicial + 1, consulta.data.stampsBalance)
+        finally:
+            remove = balance.remove_stamps(idUser, 1, self.comment)
+        self.assertEqual(self.expected, remove.get_status())
+        self.assertEqual(inicial, remove.get_data())
+
+    def testBalance_stamps_uuid(self):
+        #El identificador se acepta como cadena o como uuid.UUID.
+        idUser = uuid.UUID(self.child_user_id())
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        add = balance.add_stamps(idUser, 1, self.comment)
+        self.assertEqual(self.expected, add.get_status())
+        remove = balance.remove_stamps(idUser, 1, self.comment)
+        self.assertEqual(self.expected, remove.get_status())
+        self.assertEqual(add.get_data() - 1, remove.get_data())
+
+    def testBalance_stamps_withoutComment(self):
+        #El comentario es opcional para el servicio.
+        idUser = self.child_user_id()
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        add = balance.add_stamps(idUser, 1, None)
+        self.assertEqual(self.expected, add.get_status())
+        remove = balance.remove_stamps(idUser, 1, "")
+        self.assertEqual(self.expected, remove.get_status())
+        self.assertEqual(add.get_data() - 1, remove.get_data())
+
+    #UT de Error
+    def testBalance_add_invalidId(self):
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.add_stamps(self.invalidId, 1, self.comment)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+    def testBalance_remove_invalidId(self):
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.remove_stamps(self.invalidId, 1, self.comment)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+    def testBalance_add_notFound(self):
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.add_stamps(self.notFoundId, 1, self.comment)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+    def testBalance_remove_notFound(self):
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.remove_stamps(self.notFoundId, 1, self.comment)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+    def testBalance_add_zeroStamps(self):
+        #El servicio es quien valida que la cantidad sea mayor que cero.
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.add_stamps(self.child_user_id(), 0, self.comment)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
+        self.assertIn("Stamps", response.get_message())
+
+    def testBalance_remove_negativeStamps(self):
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.remove_stamps(self.child_user_id(), -1, self.comment)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
+        self.assertIn("Stamps", response.get_message())
+
+    def testBalance_remove_insufficientStamps(self):
+        balance = Balance(self.url, self.urlApi, os.environ["SDKTEST_TOKEN"])
+        response = balance.remove_stamps(self.child_user_id(), 999999999, self.comment)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(400, response.get_status_code())
+        self.assertIn("saldo", response.get_message())
+
+    def testBalance_invalidToken(self):
+        balance = Balance(self.url, self.urlApi, "token-invalido")
+        response = balance.add_stamps(self.child_user_id(), 1, self.comment)
+        self.assertEqual(self.expectedError, response.get_status())
+        self.assertEqual(401, response.get_status_code())
+        self.assertIsNotNone(response.get_message())
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestBalance)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 setuptools.setup(
     name='sw-sdk-python',
-    version='0.0.12.1',
+    version='0.0.13.1',
     description="SDK para Timbrado en SmarterWeb",
     url="https://github.com/lunasoft/sw-sdk-python",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
### Actividad
SS-272 — Actualización librerías - Balance (agregar y eliminar timbres) - Python
SS-273 — Actualización librerías - Usuarios (Account/User) - Python

### Qué incluye
**SS-272 — Balance**
- Se agrega la consulta de saldo por id de usuario
- Se corrigen dos llaves de la respuesta de saldo que el servicio no manda con ese nombre, y que dejaban `unlimited` y `lastTransaction.idUSer` siempre en su valor por defecto
- Se cierra la acción no contemplada en la distribución de timbres
- Las UT de asignación y remoción dejan de estar apagadas: el ciclo agrega y remueve la misma cantidad, así que el saldo queda como estaba. El idUser se toma de la cuenta en lugar de hardcodearse
- Se documenta la consulta por id y se corrigen los ejemplos de la sección

**SS-273 — Usuarios**
- Se corrige el nombre de `AccountUser/__init__.py`, sin el cual el paquete no llegaba a la distribución de la librería
- La consulta admite los parámetros de paginación y el filtro por nombre que documenta la API, y la ruta se arma con codificación de los valores
- La respuesta expone `meta` y `links`, necesarios para saber que la consulta viene paginada
- El alta, la actualización y la baja dejan de estar apagadas: el usuario que se crea se elimina en la misma prueba
- Se documenta la paginación y se corrigen los ejemplos de la sección

### Funcionalidad adicional al alcance original
- Consulta de saldo por id de usuario
- Paginación, filtro por nombre y exposición de `meta` y `links` en la consulta de usuarios

### Versión
- `0.0.12.1` → `0.0.13.1` (feature: se agrega funcionalidad)

### Criterios de aceptación
- [x] Se permite agregar y eliminar timbres de una cuenta en base a los datos proporcionados
- [x] Se permite obtener todos los usuarios, obtener usuarios por token, agregar y eliminar usuarios en base a los datos proporcionados
- [x] UTs en success
- [x] Documentación en el README
Sigue pendiente tu decisión sobre los dos puntos que te dejé al cerrar la etapa 1: el ValueError interno en stamp_distribution y el trailer Co-Authored-By de los commits, que los 4 PR anteriores no traen. Los dos se cambian antes de que esto entre a revisión si prefieres. Y dime si borro ya .sdktest.env o lo dejo para el PROMPT 7, que también lo va a necesitar.